### PR TITLE
Fix make start after rebase

### DIFF
--- a/src/otelcollector/otelcol-config-extras.yml
+++ b/src/otelcollector/otelcol-config-extras.yml
@@ -60,18 +60,20 @@ processors:
 
 exporters:
   googlecloud:
+    log:
+      default_log_name: opentelemetry.io/opentelemetry-demo
 
   googlemanagedprometheus:
 
 service:
   pipelines:
     logs:
-      processors: [memory_limiter, resourcedetection, resource, batch]
+      processors: [memory_limiter, resourcedetection, batch]
       exporters: [googlecloud]
     traces:
-      processors: [memory_limiter, resourcedetection, resource, batch]
+      processors: [memory_limiter, resourcedetection, batch]
       exporters: [googlecloud] #spanmetrics disabled
     metrics:
       receivers: [otlp] #spanmetrics disabled
-      processors: [filter/ottl, filter/currency, memory_limiter, resourcedetection, transform, transform/collision, resource, batch]
+      processors: [filter/currency, memory_limiter, resourcedetection, transform/collision, batch]
       exporters: [googlemanagedprometheus]


### PR DESCRIPTION
`make start` (docker compose) gave errors like the following after merging https://github.com/GoogleCloudPlatform/opentelemetry-demo/pull/12:

```
Error: invalid configuration: service::pipelines::metrics: references processor "filter/ottl" which is not configured
2024/02/15 20:16:25 collector server run finished with error: invalid configuration: service::pipelines::metrics: references processor "filter/ottl" which is not configured
Error: invalid configuration: service::pipelines::metrics: references processor "filter/ottl" which is not configured
2024/02/15 20:16:29 collector server run finished with error: invalid configuration: service::pipelines::metrics: references processor "filter/ottl" which is not configured
Error: invalid configuration: service::pipelines::logs: references processor "resource" which is not configured
2024/02/15 20:16:31 collector server run finished with error: invalid configuration: service::pipelines::logs: references processor "resource" which is not configured
Error: invalid configuration: service::pipelines::traces: references processor "resource" which is not configured
2024/02/15 20:16:32 collector server run finished with error: invalid configuration: service::pipelines::traces: references processor "resource" which is not configured
Error: invalid configuration: service::pipelines::logs: references processor "resource" which is not configured
2024/02/15 20:16:34 collector server run finished with error: invalid configuration: service::pipelines::logs: references processor "resource" which is not configured
Error: invalid configuration: service::pipelines::metrics: references processor "filter/ottl" which is not configured
2024/02/15 20:16:37 collector server run finished with error: invalid configuration: service::pipelines::metrics: references processor "filter/ottl" which is not configured
Error: invalid configuration: service::pipelines::metrics: references processor "filter/ottl" which is not configured
2024/02/15 20:16:41 collector server run finished with error: invalid configuration: service::pipelines::metrics: references processor "filter/ottl" which is not configured
Error: invalid configuration: service::pipelines::traces: references processor "resource" which is not configured
2024/02/15 20:16:49 collector server run finished with error: invalid configuration: service::pipelines::traces: references processor "resource" which is not configured
Error: invalid configuration: service::pipelines::metrics: references processor "filter/ottl" which is not configured
2024/02/15 20:17:03 collector server run finished with error: invalid configuration: service::pipelines::metrics: references processor "filter/ottl" which is not configured
```

Looks like the default config was changed upstream to not include these anymore, so our `extras.yml` file cause the error when it was merged. Our `extras` file assumed these processors were declared in the base file, but we have to declare them in the pipeline because yaml lists are overwritten (not merged) when yaml files are merged.

These changes do not seem to be in the helm chart yet (https://github.com/open-telemetry/opentelemetry-helm-charts/blob/3f51bc21e3ae17d997703d3b408a35c7b0f56a2d/charts/opentelemetry-demo/values.yaml), so this PR doesn't touch the helm chart values.yml we provide.

Tested manually. Now that we are caught up to upstream, we should add https://github.com/GoogleCloudPlatform/opentelemetry-demo/issues/17 before doing more rebases