### PR TITLE
Support `kubectl apply` steps

### DIFF
--- a/README_GCP.md
+++ b/README_GCP.md
@@ -65,12 +65,14 @@ helm install my-otel-demo open-telemetry/opentelemetry-demo --namespace otel-dem
 
 ### (Alternative) Using `kubectl apply`
 
-Installing with the Helm chart is recommended, but you can also use `kubectl apply` to install the manifests directly.
+Installing with the Helm chart is recommended, but you can also use `kubectl
+apply` to install the manifests directly.
 
 First, make sure you have followed the Workload Identity setup steps above.
 
-Update [`kubernetes/opentelemetry-demo.yaml`](kubernetes/opentelemetry-demo.yaml) to annotate the
-Kubernetes service account with your project:
+Update
+[`kubernetes/opentelemetry-demo.yaml`](kubernetes/opentelemetry-demo.yaml) to
+annotate the Kubernetes service account with your project:
 
 ```console
 sed -i "s/%GCLOUD_PROJECT%/${GCLOUD_PROJECT}/g" ./kubernetes/opentelemetry-demo.yaml

--- a/README_GCP.md
+++ b/README_GCP.md
@@ -38,7 +38,7 @@ gcloud projects add-iam-policy-binding ${GCLOUD_PROJECT} \
     --role "roles/cloudtrace.agent"
 gcloud iam service-accounts add-iam-policy-binding opentelemetry-demo@${GCLOUD_PROJECT}.iam.gserviceaccount.com \
     --role roles/iam.workloadIdentityUser \
-    --member "serviceAccount:${GCLOUD_PROJECT}.svc.id.goog[default/opentelemetry-demo]"
+    --member "serviceAccount:${GCLOUD_PROJECT}.svc.id.goog[otel-demo/opentelemetry-demo-otelcol]"
 ```
 
 Update [`gcp-config-valus.yml`](gcp-config-values.yml) to annotate the
@@ -57,9 +57,10 @@ service account and annotate it to use Workload Identity.
 Follow the [OpenTelemetry docs to run the Helm chart](https://opentelemetry.io/docs/demo/kubernetes-deployment):
 
 ```console
+kubectl create namespace otel-demo
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 helm repo update
-helm install my-otel-demo open-telemetry/opentelemetry-demo --values gcp-config-values.yml --version 0.29.1
+helm install my-otel-demo open-telemetry/opentelemetry-demo --namespace otel-demo --values gcp-config-values.yml --version 0.29.1
 ```
 
 ### (Alternative) Using `kubectl apply`

--- a/README_GCP.md
+++ b/README_GCP.md
@@ -69,7 +69,7 @@ Installing with the Helm chart is recommended, but you can also use `kubectl app
 
 First, make sure you have followed the Workload Identity setup steps above.
 
-Update [`gcp-config-valus.yml`](gcp-config-values.yml) to annotate the
+Update [`kubernetes/opentelemetry-demo.yaml`](kubernetes/opentelemetry-demo.yaml) to annotate the
 Kubernetes service account with your project:
 
 ```console

--- a/README_GCP.md
+++ b/README_GCP.md
@@ -62,6 +62,25 @@ helm repo update
 helm install my-otel-demo open-telemetry/opentelemetry-demo --values gcp-config-values.yml --version 0.29.1
 ```
 
+### (Alternative) Using `kubectl apply`
+
+Installing with the Helm chart is recommended, but you can also use `kubectl apply` to install the manifests directly.
+
+First, make sure you have followed the Workload Identity setup steps above.
+
+Update [`gcp-config-valus.yml`](gcp-config-values.yml) to annotate the
+Kubernetes service account with your project:
+
+```console
+sed -i "s/%GCLOUD_PROJECT%/${GCLOUD_PROJECT}/g" ./kubernetes/opentelemetry-demo.yaml
+```
+
+Install the manifests:
+
+```console
+kubectl apply -n otel-demo -f ./kubernetes/opentelemetry-demo.yaml
+```
+
 ## Running on GCE
 
 Follow the [OpenTelemetry docs to run with Docker](https://opentelemetry.io/docs/demo/docker-deployment/):

--- a/gcp-config-values.yml
+++ b/gcp-config-values.yml
@@ -21,7 +21,7 @@ opentelemetry-collector:
   serviceAccount:
     create: true
     annotations: {"iam.gke.io/gcp-service-account":"opentelemetry-demo@%GCLOUD_PROJECT%.iam.gserviceaccount.com"}
-    name: "opentelemetry-demo"
+    name: "opentelemetry-demo-otelcol"
 
   config:
     processors:

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -35,6 +35,8 @@ kind: ServiceAccount
 metadata:
   name: opentelemetry-demo-otelcol
   namespace: otel-demo
+  annotations:
+    iam.gke.io/gcp-service-account: "opentelemetry-demo@%GCLOUD_PROJECT%.iam.gserviceaccount.com"
   labels:
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: opentelemetry-demo

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -179,10 +179,21 @@ data:
         endpoint: http://opentelemetry-demo-prometheus-server:9090/api/v1/otlp
         tls:
           insecure: true
+
+      googlecloud:
+        log:
+          default_log_name: opentelemetry.io/opentelemetry-demo
+
+      googlemanagedprometheus:
+
     extensions:
       health_check: {}
     processors:
-      batch: {}
+      batch:
+        send_batch_max_size: 200
+        send_batch_size: 200
+        timeout: 5s
+
       filter/ottl:
         error_mode: ignore
         metrics:
@@ -212,14 +223,18 @@ data:
         - sources:
           - from: connection
       memory_limiter:
-        check_interval: 5s
-        limit_percentage: 80
-        spike_limit_percentage: 25
+        check_interval: 1s
+        limit_percentage: 65
+        spike_limit_percentage: 20
       resource:
         attributes:
         - action: insert
           from_attribute: k8s.pod.uid
           key: service.instance.id
+      resourcedetection:
+        detectors: [gcp]
+        timeout: 10s
+
       transform:
         metric_statements:
         - context: metric
@@ -227,6 +242,29 @@ data:
           - set(description, "") where name == "queueSize"
           - set(description, "") where name == "rpc.server.duration"
           - set(description, "") where name == "http.client.duration"
+      transform/collision:
+        metric_statements:
+        - context: datapoint
+          statements:
+          - set(attributes["exported_location"], attributes["location"])
+          - delete_key(attributes, "location")
+          - set(attributes["exported_cluster"], attributes["cluster"])
+          - delete_key(attributes, "cluster")
+          - set(attributes["exported_namespace"], attributes["namespace"])
+          - delete_key(attributes, "namespace")
+          - set(attributes["exported_job"], attributes["job"])
+          - delete_key(attributes, "job")
+          - set(attributes["exported_instance"], attributes["instance"])
+          - delete_key(attributes, "instance")
+          - set(attributes["exported_project_id"], attributes["project_id"])
+          - delete_key(attributes, "project_id")
+
+      # See https://github.com/open-telemetry/opentelemetry-demo/issues/1330
+      filter/currency:
+        metrics:
+          metric:
+          - 'IsMatch(name, "(.*)app_currency(.*)")'
+
     receivers:
       jaeger:
         protocols:
@@ -262,41 +300,43 @@ data:
       pipelines:
         logs:
           exporters:
-          - debug
+          - googlecloud
           processors:
           - k8sattributes
+          - resourcedetection
+          - resource
           - memory_limiter
           - batch
           receivers:
           - otlp
         metrics:
           exporters:
-          - otlphttp/prometheus
-          - debug
+          - googlemanagedprometheus
           processors:
           - k8sattributes
           - memory_limiter
           - filter/ottl
+          - filter/currency
+          - resourcedetection
           - transform
+          - transform/collision
           - resource
           - batch
           receivers:
           - otlp
-          - spanmetrics
+          #- spanmetrics
         traces:
           exporters:
-          - otlp
-          - debug
-          - spanmetrics
+          - googlecloud
+          #- spanmetrics
           processors:
           - k8sattributes
           - memory_limiter
+          - resourcedetection
           - resource
           - batch
           receivers:
           - otlp
-          - jaeger
-          - zipkin
       telemetry:
         metrics:
           address: ${env:MY_POD_IP}:8888


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-demo/issues/24

Update `kubernetes/opentelemetry-demo.yaml` file to match our Helm and docker-compose deployments. This file is generated in the upstream demo repo, but since we aren't generating it we can edit it directly and manually handle conflicts for now.

This also makes some updates to the Workload Identity steps to align the Helm/Kubectl install. By default, kubectl apply will install the collector in the `otel-demo` namespace while Helm installs in `default`. Instead of making more changes to the kubectl manifests or having 2 sets of instructions I just updated the commands to Helm install in the `otel-demo` namespace too.

In this change, I noticed that some of the processors that were removed in the Helm chart (see https://github.com/GoogleCloudPlatform/opentelemetry-demo/issues/23) were still present in this file. I don't know if that's because of catching this in the middle of an upstream release, or if upstream just didn't update that file, but I manually tested this and it still deploys. When we have integration testing that will have to check this when we rebase for the next release.

Tested both `kubectl apply` and Helm install manually.