### PR TITLE
Add Cloud Build deploy config

### DIFF
--- a/.licenserc.json
+++ b/.licenserc.json
@@ -46,6 +46,7 @@
         "src/featureflagservice/priv/",
         "src/productcatalogservice/genproto/",
         "internal/tools/",
-        "gcp-config-values.yml"
+        "gcp-config-values.yml",
+        "cloudbuild-deploy.yaml"
     ]
   }

--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -1,0 +1,34 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+# set the project ID in the k8s manifest for service account/workload identity
+- name: 'ubuntu'
+  id: Replace
+  script: |
+    #!/usr/bin/env bash
+    sed -i "s/%GCLOUD_PROJECT%/${PROJECT_ID}/g" ./kubernetes/opentelemetry-demo.yaml
+
+# deploy the manifests to the otel-demo namespace in GKE
+- name: 'gcr.io/cloud-builders/kubectl'
+  id: Deploy
+  args:
+  - 'apply'
+  - '-n'
+  - 'otel-demo'
+  - '-f'
+  - './kubernetes/opentelemetry-demo.yaml'
+  env:
+  - 'CLOUDSDK_COMPUTE_REGION=${LOCATION}'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER}'


### PR DESCRIPTION
This uses the `kubectl apply` steps to deploy the demo to a GKE cluster. The cluster name is set in a substitution in the GCP project to prevent leaking that info, and to allow other users to re-use this file.