### PR TITLE
Add PROJECT_ID env var substitution

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -19,6 +19,8 @@ steps:
   script: |
     #!/usr/bin/env bash
     sed -i "s/%GCLOUD_PROJECT%/${PROJECT_ID}/g" ./kubernetes/opentelemetry-demo.yaml
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
 
 # deploy the manifests to the otel-demo namespace in GKE
 - name: 'gcr.io/cloud-builders/kubectl'


### PR DESCRIPTION
Looks like even though `PROJECT_ID` is a [default substitution](https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values#using_user-defined_substitutions), it's not just available as an env var by default, because the output in the first cloud build run I did with this is coming up empty.