### PR TITLE
Re-enable currency service metrics

### DIFF
--- a/gcp-config-values.yml
+++ b/gcp-config-values.yml
@@ -56,12 +56,6 @@ opentelemetry-collector:
           - set(attributes["exported_project_id"], attributes["project_id"])
           - delete_key(attributes, "project_id")
 
-      # See https://github.com/open-telemetry/opentelemetry-demo/issues/1330
-      filter/currency:
-        metrics:
-          metric:
-          - 'IsMatch(name, "(.*)app_currency(.*)")'
-
     exporters:
       googlecloud:
         log:
@@ -79,5 +73,5 @@ opentelemetry-collector:
           exporters: [googlecloud] #spanmetrics disabled
         metrics:
           receivers: [otlp] #spanmetrics disabled
-          processors: [filter/currency, memory_limiter, resourcedetection, transform/collision, resource, batch]
+          processors: [memory_limiter, resourcedetection, transform/collision, resource, batch]
           exporters: [googlemanagedprometheus]

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -261,12 +261,6 @@ data:
           - set(attributes["exported_project_id"], attributes["project_id"])
           - delete_key(attributes, "project_id")
 
-      # See https://github.com/open-telemetry/opentelemetry-demo/issues/1330
-      filter/currency:
-        metrics:
-          metric:
-          - 'IsMatch(name, "(.*)app_currency(.*)")'
-
     receivers:
       jaeger:
         protocols:
@@ -318,7 +312,6 @@ data:
           - k8sattributes
           - memory_limiter
           - filter/ottl
-          - filter/currency
           - resourcedetection
           - transform
           - transform/collision

--- a/src/otelcollector/otelcol-config-extras.yml
+++ b/src/otelcollector/otelcol-config-extras.yml
@@ -52,12 +52,6 @@ processors:
       - set(attributes["exported_project_id"], attributes["project_id"])
       - delete_key(attributes, "project_id")
 
-  # See https://github.com/open-telemetry/opentelemetry-demo/issues/1330
-  filter/currency:
-    metrics:
-      metric:
-      - 'IsMatch(name, "(.*)app_currency(.*)")'
-
 exporters:
   googlecloud:
     log:
@@ -75,5 +69,5 @@ service:
       exporters: [googlecloud] #spanmetrics disabled
     metrics:
       receivers: [otlp] #spanmetrics disabled
-      processors: [filter/currency, memory_limiter, resourcedetection, transform/collision, batch]
+      processors: [memory_limiter, resourcedetection, transform/collision, batch]
       exporters: [googlemanagedprometheus]


### PR DESCRIPTION
Metrics from the currency app were filtered due to https://github.com/open-telemetry/opentelemetry-demo/issues/1330, which has been resolved upstream. Re-enabling this now so we can get telemetry from all available services.