### PR TITLE
Register frontendproxy service with service directory for uptime checks

### DIFF
--- a/.licenserc.json
+++ b/.licenserc.json
@@ -46,6 +46,7 @@
         "src/featureflagservice/priv/",
         "src/productcatalogservice/genproto/",
         "internal/tools/",
+        "kubernetes/service-directory-registration.yaml",
         "gcp-config-values.yml",
         "cloudbuild-deploy.yaml"
     ]

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -8589,8 +8589,11 @@ metadata:
     app.kubernetes.io/name: opentelemetry-demo-frontendproxy
     app.kubernetes.io/version: "1.7.0"
     app.kubernetes.io/part-of: opentelemetry-demo
+  annotations:
+    networking.gke.io/internal-load-balancer-allow-global-access: "true"
+    networking.gke.io/load-balancer-type: Internal
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   ports:
     - port: 8080
       name: tcp-service

--- a/kubernetes/service-directory-registration.yaml
+++ b/kubernetes/service-directory-registration.yaml
@@ -12,25 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-steps:
-# set the project ID in the k8s manifest for service account/workload identity
-- name: 'ubuntu'
-  id: Replace
-  script: |
-    #!/usr/bin/env bash
-    sed -i "s/%GCLOUD_PROJECT%/${PROJECT_ID}/g" ./kubernetes/opentelemetry-demo.yaml
-  env:
-  - 'PROJECT_ID=$PROJECT_ID'
-
-# deploy the manifests to the otel-demo namespace in GKE
-- name: 'gcr.io/cloud-builders/kubectl'
-  id: Deploy
-  args:
-  - 'apply'
-  - '-n'
-  - 'otel-demo'
-  - '-f'
-  - './kubernetes/.'
-  env:
-  - 'CLOUDSDK_COMPUTE_REGION=${LOCATION}'
-  - 'CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER}'
+# This resource registers kubernetes services with the GCP service directory so
+# they can be used for uptime checks. See
+# https://cloud.google.com/service-directory/docs/sd-gke-overview.
+apiVersion: networking.gke.io/v1alpha1
+kind: ServiceDirectoryRegistrationPolicy
+metadata:
+  # Only the name "default" is allowed.
+  name: default
+spec:
+  resources:
+    - kind: Service
+      # match the frontendproxy service
+      selector:
+        matchLabels:
+          app.kubernetes.io/part-of: "opentelemetry-demo"
+          app.kubernetes.io/component: frontendproxy


### PR DESCRIPTION
Change service to an internal load balancer so it can be used for uptime checks.

Register the service with service directory.

I've already applied both the updated service and the service directory registration to the cluster, and the uptime checks work properly.