### PR TITLE
Switch to Workload Identity Federation for GKE

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 steps:
-# set the project ID in the k8s manifest for service account/workload identity
 - name: ghcr.io/helmfile/helmfile
   id: Generate
   script: |
     #!/usr/bin/env bash
     apk add make
-    make generate-kubernetes-manifests HELMFILE_FLAGS="--environment production --state-values-set-string workload_identity_project_id=$PROJECT_ID,auth_extension_project_id=$PROJECT_ID,auth_extension_quota_project_id=$PROJECT_ID,otlp_endpoint=https://us-central1-telemetry.googleapis.com:443"
+    make generate-kubernetes-manifests HELMFILE_FLAGS="--environment production --state-values-set-string auth_extension_project_id=$PROJECT_ID,auth_extension_quota_project_id=$PROJECT_ID,otlp_endpoint=https://us-central1-telemetry.googleapis.com:443"
   env:
   - 'PROJECT_ID=$PROJECT_ID'
 

--- a/gcp/helmfile.yaml
+++ b/gcp/helmfile.yaml
@@ -15,8 +15,7 @@
 environments:
   default:
     values:
-      - workload_identity_project_id: "%GCLOUD_PROJECT%"
-        namespace: otel-demo
+      - namespace: otel-demo
   production:
     values:
       - namespace: otel-demo

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -17,9 +17,6 @@ metadata:
     app.kubernetes.io/name: otelcol
     app.kubernetes.io/instance: opentelemetry-demo
     app.kubernetes.io/version: "0.105.0"
-    
-  annotations:
-    iam.gke.io/gcp-service-account: "opentelemetry-demo@%GCLOUD_PROJECT%.iam.gserviceaccount.com"
 ---
 # Source: opentelemetry-demo/templates/serviceaccount.yaml
 apiVersion: v1


### PR DESCRIPTION
GCP now [supports (and recommends) ](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to)directly using Kubernetes Service Accounts on IAM ACLs. This PR removes all instructions for manually creating a service account, and replaces it with the new Workload Identity Federation for GKE.