### PR TITLE
Double-write metrics to otlphttp exporter and googlemanagedprometheus

### DIFF
--- a/gcp/opentelemetry-demo-features.yaml.gotmpl
+++ b/gcp/opentelemetry-demo-features.yaml.gotmpl
@@ -62,4 +62,7 @@ opentelemetry-collector:
         traces:
           processors: [k8sattributes, memory_limiter, resourcedetection, resource, resource/gcp_project_id, batch]
           exporters: [otlphttp/gcp_auth]
+        metrics/otlp:
+          processors: [k8sattributes, memory_limiter, filter/currency, resourcedetection, transform/collision, resource, resource/gcp_project_id, transform/metricprefix, batch]
+          exporters: [otlphttp/gcp_auth]
 {{ end }}

--- a/src/otelcollector/otelcol-config-extras.yml
+++ b/src/otelcollector/otelcol-config-extras.yml
@@ -35,6 +35,12 @@ processors:
     detectors: [gcp]
     timeout: 10s
 
+  transform/metricprefix:
+    metric_statements:
+    - context: metric
+      statements:
+      - set(name, Concat(["otlp", name], "."))
+
   transform/collision:
     metric_statements:
     - context: datapoint


### PR DESCRIPTION
# Changes

Double-write metrics to the GMP and OTLP exporters.  Rename metrics exported using the OTLP exporter with an "otlp-" prefix so that they do not collide with existing metrics.
