### PR TITLE
Move metricprefix transform processor into the demo features

### DIFF
--- a/gcp/opentelemetry-demo-features.yaml.gotmpl
+++ b/gcp/opentelemetry-demo-features.yaml.gotmpl
@@ -36,6 +36,11 @@ opentelemetry-collector:
           authenticator: googleclientauth
 
     processors:
+      transform/metricprefix:
+        metric_statements:
+        - context: metric
+          statements:
+          - set(name, Concat(["otlp", name], "."))
       resource/gcp_project_id:
         attributes:
         - action: insert

--- a/src/otelcollector/otelcol-config-extras.yml
+++ b/src/otelcollector/otelcol-config-extras.yml
@@ -35,12 +35,6 @@ processors:
     detectors: [gcp]
     timeout: 10s
 
-  transform/metricprefix:
-    metric_statements:
-    - context: metric
-      statements:
-      - set(name, Concat(["otlp", name], "."))
-
   transform/collision:
     metric_statements:
     - context: datapoint


### PR DESCRIPTION
# Changes


I put the transform processor into the wrong configuration file in https://github.com/GoogleCloudPlatform/opentelemetry-demo/pull/197.  This fixes that.