### PR TITLE
Use default scopes for gcp auth

### DIFF
--- a/gcp/opentelemetry-demo-features.yaml.gotmpl
+++ b/gcp/opentelemetry-demo-features.yaml.gotmpl
@@ -51,9 +51,6 @@ opentelemetry-collector:
 
     extensions:
       googleclientauth:
-        scopes:
-        - "https://www.googleapis.com/auth/trace.append"
-        - "https://www.googleapis.com/auth/cloud-platform"
 {{ with .Values | getOrNil "auth_extension_project_id" }}
         project: "{{ . }}"
 {{ end }}


### PR DESCRIPTION
# Changes

Fixes permission denied errors.  We were explicitly setting our scopes to only include what was needed to write traces.  We should just use the default scopes instead, which includes writing metrics, logs, and traces