### PR TITLE
Switch to writing metrics to the staging endpoint

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -42,7 +42,7 @@ steps:
   script: |
     #!/usr/bin/env bash
     export PATH=$PATH:$(pwd)
-    helmfile apply -f gcp/helmfile.yaml --environment production --state-values-set-string workload_identity_project_id=$PROJECT_ID,auth_extension_project_id=$PROJECT_ID,auth_extension_quota_project_id=$PROJECT_ID,otlp_endpoint=$_OTLP_ENDPOINT
+    helmfile apply -f gcp/helmfile.yaml --environment production --state-values-set-string workload_identity_project_id=$PROJECT_ID,auth_extension_project_id=$PROJECT_ID,auth_extension_quota_project_id=$PROJECT_ID,otlp_endpoint=$_OTLP_ENDPOINT,otlp_staging_endpoint=$_OTLP_STAGING_ENDPOINT
   # yamllint enable rule:line-length
   automapSubstitutions: true
   env:
@@ -51,3 +51,4 @@ steps:
   - 'CLOUDSDK_CONTAINER_CLUSTER=${_GKE_CLUSTER}'
 substitutions:
   _OTLP_ENDPOINT: ${_OTLP_ENDPOINT}
+  _OTLP_STAGING_ENDPOINT: ${_OTLP_STAGING_ENDPOINT}

--- a/gcp/opentelemetry-demo-features.yaml.gotmpl
+++ b/gcp/opentelemetry-demo-features.yaml.gotmpl
@@ -27,6 +27,13 @@ opentelemetry-collector:
 {{ if hasKey .Values "otlp_endpoint" }}
   config:
     exporters:
+      otlphttp/gcp_auth_staging:
+        encoding: json
+{{ with .Values | getOrNil "otlp_staging_endpoint" }}
+        endpoint: "{{ . }}"
+{{ end }}
+        auth:
+          authenticator: googleclientauth
       otlphttp/gcp_auth:
         encoding: json
 {{ with .Values | getOrNil "otlp_endpoint" }}
@@ -67,5 +74,5 @@ opentelemetry-collector:
         metrics/otlp:
           receivers: [otlp]
           processors: [k8sattributes, memory_limiter, filter/currency, resourcedetection, transform/collision, resource, resource/gcp_project_id, transform/metricprefix, batch]
-          exporters: [otlphttp/gcp_auth]
+          exporters: [otlphttp/gcp_auth_staging]
 {{ end }}


### PR DESCRIPTION
This writes metrics to the staging OTLP service instead of the prod service.
