### PR TITLE
Drop flagd metrics, which are sent too frequently

### DIFF
--- a/gcp/opentelemetry-demo-values.yaml
+++ b/gcp/opentelemetry-demo-values.yaml
@@ -74,10 +74,11 @@ opentelemetry-collector:
           - delete_key(attributes, "project_id")
 
       # See https://github.com/open-telemetry/opentelemetry-demo/issues/1330
-      filter/currency:
+      # flagd metrics are written too often.
+      filter/too_frequent:
         metrics:
           metric:
-          - 'IsMatch(name, "(.*)app_currency(.*)")'
+          - '(IsMatch(name, "(.*)app_currency(.*)")) or (resource.attributes["service.name"] == "flagd")'
 
     exporters:
       googlecloud:
@@ -101,5 +102,5 @@ opentelemetry-collector:
           exporters: [googlecloud]  # spanmetrics disabled
         metrics:
           receivers: [otlp]  # spanmetrics disabled
-          processors: [memory_limiter, filter/currency, resourcedetection, transform/collision, resource, batch]
+          processors: [memory_limiter, filter/too_frequent, resourcedetection, transform/collision, resource, batch]
           exporters: [googlemanagedprometheus]

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -60,10 +60,10 @@ data:
         send_batch_max_size: 200
         send_batch_size: 200
         timeout: 5s
-      filter/currency:
+      filter/too_frequent:
         metrics:
           metric:
-          - IsMatch(name, "(.*)app_currency(.*)")
+          - (IsMatch(name, "(.*)app_currency(.*)")) or (resource.attributes["service.name"] == "flagd")
       k8sattributes:
         extract:
           metadata:
@@ -181,7 +181,7 @@ data:
           processors:
           - k8sattributes
           - memory_limiter
-          - filter/currency
+          - filter/too_frequent
           - resourcedetection
           - transform/collision
           - resource

--- a/src/otelcollector/otelcol-config-extras.yml
+++ b/src/otelcollector/otelcol-config-extras.yml
@@ -53,10 +53,11 @@ processors:
       - delete_key(attributes, "project_id")
 
   # See https://github.com/open-telemetry/opentelemetry-demo/issues/1330
-  filter/currency:
+  # flagd metrics are written too often.
+  filter/too_frequent:
     metrics:
       metric:
-      - 'IsMatch(name, "(.*)app_currency(.*)")'
+      - '(IsMatch(name, "(.*)app_currency(.*)")) or (resource.attributes["service.name"] == "flagd")'
 
 exporters:
   googlecloud:
@@ -75,5 +76,5 @@ service:
       exporters: [googlecloud] #spanmetrics disabled
     metrics:
       receivers: [otlp] #spanmetrics disabled
-      processors: [filter/currency, memory_limiter, resourcedetection, transform/collision, batch]
+      processors: [filter/too_frequent, memory_limiter, resourcedetection, transform/collision, batch]
       exporters: [googlemanagedprometheus]


### PR DESCRIPTION
# Changes

Drop flagd metrics, which are written every second.  This is spamming logs in the demo project.