### PR TITLE
Fix missing processor rename

### DIFF
--- a/gcp/opentelemetry-demo-features.yaml.gotmpl
+++ b/gcp/opentelemetry-demo-features.yaml.gotmpl
@@ -73,6 +73,6 @@ opentelemetry-collector:
           exporters: [otlphttp/gcp_auth]
         metrics/otlp:
           receivers: [otlp]
-          processors: [k8sattributes, memory_limiter, filter/currency, resourcedetection, transform/collision, resource, resource/gcp_project_id, transform/metricprefix, batch]
+          processors: [k8sattributes, memory_limiter, filter/too_frequent, resourcedetection, transform/collision, resource, resource/gcp_project_id, transform/metricprefix, batch]
           exporters: [otlphttp/gcp_auth_staging]
 {{ end }}


### PR DESCRIPTION
# Changes

Fix missing processor rename after https://github.com/GoogleCloudPlatform/opentelemetry-demo/pull/203
