### PR TITLE
Remove prefix for staging environment

### DIFF
--- a/gcp/opentelemetry-demo-features.yaml.gotmpl
+++ b/gcp/opentelemetry-demo-features.yaml.gotmpl
@@ -43,11 +43,6 @@ opentelemetry-collector:
           authenticator: googleclientauth
 
     processors:
-      transform/metricprefix:
-        metric_statements:
-        - context: metric
-          statements:
-          - set(name, Concat(["otlp", name], "."))
       resource/gcp_project_id:
         attributes:
         - action: insert
@@ -73,6 +68,6 @@ opentelemetry-collector:
           exporters: [otlphttp/gcp_auth]
         metrics/otlp:
           receivers: [otlp]
-          processors: [k8sattributes, memory_limiter, filter/too_frequent, resourcedetection, transform/collision, resource, resource/gcp_project_id, transform/metricprefix, batch]
+          processors: [k8sattributes, memory_limiter, filter/too_frequent, resourcedetection, transform/collision, resource, resource/gcp_project_id, batch]
           exporters: [otlphttp/gcp_auth_staging]
 {{ end }}


### PR DESCRIPTION
# Changes

Since these metrics are being written to staging, we don't need to worry about name collisions with the GMP exporter.
