### PR TITLE
Revert "Use OTLP exclusively instead of double-writing spans (#190)"

### DIFF
--- a/gcp/opentelemetry-demo-features.yaml.gotmpl
+++ b/gcp/opentelemetry-demo-features.yaml.gotmpl
@@ -65,7 +65,7 @@ opentelemetry-collector:
       pipelines:
         traces:
           processors: [k8sattributes, memory_limiter, resourcedetection, resource, resource/gcp_project_id, batch]
-          exporters: [otlphttp/gcp_auth]
+          exporters: [googlecloud, otlphttp/gcp_auth]
         metrics/otlp:
           receivers: [otlp, prometheus]
           processors: [k8sattributes, memory_limiter, filter/too_frequent, resourcedetection, transform/collision, resource, resource/gcp_project_id, batch]


### PR DESCRIPTION
This reverts commit 0f71116b9d13c79888139964e49326eff6b40331.

This works around [b/392590572](https://b.corp.google.com/issues/392590572), which should be fixed some time in Q1.