### PR TITLE
Migrate to OTLP for self-observability

### DIFF
--- a/gcp/opentelemetry-demo-features.yaml.gotmpl
+++ b/gcp/opentelemetry-demo-features.yaml.gotmpl
@@ -67,7 +67,7 @@ opentelemetry-collector:
           processors: [k8sattributes, memory_limiter, resourcedetection, resource, resource/gcp_project_id, batch]
           exporters: [googlecloud, otlphttp/gcp_auth]
         metrics/otlp:
-          receivers: [otlp, prometheus]
+          receivers: [otlp]
           processors: [k8sattributes, memory_limiter, filter/too_frequent, resourcedetection, transform/collision, resource, resource/gcp_project_id, batch]
           exporters: [otlphttp/gcp_auth_staging]
 {{ end }}

--- a/gcp/opentelemetry-demo-values.yaml
+++ b/gcp/opentelemetry-demo-values.yaml
@@ -95,7 +95,12 @@ opentelemetry-collector:
     service:
       telemetry:
         metrics:
-          address: ${env:MY_POD_IP}:8888
+          readers:
+          - periodic:
+              exporter:
+                otlp:
+                  protocol: grpc/protobuf
+                  endpoint: ${env:MY_POD_IP}:4317
       pipelines:
         logs:
           processors: [resourcedetection, resource, memory_limiter, batch]
@@ -104,6 +109,6 @@ opentelemetry-collector:
           processors: [memory_limiter, resourcedetection, resource, batch]
           exporters: [googlecloud]  # spanmetrics disabled
         metrics:
-          receivers: [otlp, prometheus]  # spanmetrics disabled
+          receivers: [otlp]  # spanmetrics disabled
           processors: [memory_limiter, filter/too_frequent, resourcedetection, transform/collision, resource, batch]
           exporters: [googlemanagedprometheus]


### PR DESCRIPTION
Related to https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/issues/34.  Having start times will enable the otlpmetric branch to fully replace the googlemanagedprometheus exporter.