### PR TITLE
Switch from filter to interval processor

### DIFF
--- a/gcp/opentelemetry-demo-values.yaml
+++ b/gcp/opentelemetry-demo-values.yaml
@@ -76,12 +76,9 @@ opentelemetry-collector:
           - set(attributes["exported_project_id"], attributes["project_id"])
           - delete_key(attributes, "project_id")
 
-      # See https://github.com/open-telemetry/opentelemetry-demo/issues/1330
-      # flagd metrics are written too often.
-      filter/too_frequent:
-        metrics:
-          metric:
-          - '(IsMatch(name, "(.*)app_currency(.*)")) or (resource.attributes["service.name"] == "flagd")'
+      interval:
+        # Don't allow anything more often than 30 seconds.
+        interval: 30s
 
     exporters:
       googlecloud:
@@ -108,5 +105,5 @@ opentelemetry-collector:
           exporters: [googlecloud]  # spanmetrics disabled
         metrics:
           receivers: [otlp, prometheus]  # spanmetrics disabled
-          processors: [memory_limiter, filter/too_frequent, resourcedetection, transform/collision, resource, batch]
+          processors: [memory_limiter, interval, resourcedetection, transform/collision, resource, batch]
           exporters: [googlemanagedprometheus]

--- a/gcp/opentelemetry-demo-values.yaml
+++ b/gcp/opentelemetry-demo-values.yaml
@@ -40,6 +40,9 @@ opentelemetry-collector:
     create: true
     name: "opentelemetry-demo-otelcol"
 
+  image:
+    tag: 0.118.0
+
   config:
     processors:
       memory_limiter:


### PR DESCRIPTION
Instead of removing specific metrics that are sent too often, switch to the interval processor.

To do this, I need to update the collector to v0.118.0.