### PR TITLE
switch to json logging so log severity is properly displayed

### DIFF
--- a/gcp/opentelemetry-demo-values.yaml
+++ b/gcp/opentelemetry-demo-values.yaml
@@ -94,6 +94,8 @@ opentelemetry-collector:
 
     service:
       telemetry:
+        logs:
+          encoding: json
         metrics:
           address: ${env:MY_POD_IP}:8888
       pipelines:


### PR DESCRIPTION
Same as https://github.com/GoogleCloudPlatform/otlp-k8s-ingest/pull/36, but for the demo