### PR TITLE
Remove unused redisreceiver in the OpenTelemetry Collector Config

### DIFF
--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -155,9 +155,6 @@ data:
             static_configs:
             - targets:
               - ${env:MY_POD_IP}:8888
-      redis:
-        collection_interval: 10s
-        endpoint: valkey-cart:6379
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
     service:


### PR DESCRIPTION
# Changes

Please provide a brief description of the changes here.
The `ConfigMap` used to configure the Collector declared a redis receiver that was not being used within the pipeline. This PR removes the used receiver.

## Merge Requirements

For new features contributions please make sure you have completed the following
essential items:

* [ ] `CHANGELOG.md` updated to document new feature additions
* [ ] Appropriate documentation updates in the [docs][]
* [ ] Appropriate Helm chart updates in the [helm-charts][]

<!--
A Pull Request that modifies instrumentation code will likely require an
update in docs. Please make sure to update the opentelemetry.io repo with any
docs changes.

A Pull Request that modifies docker-compose.yaml, otelcol-config.yaml, or
Grafana dashboards, will likely require an update to the Demo Helm chart.
Other changes affecting how a service is deployed will also likely require an
update to the Demo Helm chart.
-->

Maintainers will not merge until the above have been completed. If you're unsure
which docs need to be changed ping the
[@open-telemetry/demo-approvers](https://github.com/orgs/open-telemetry/teams/demo-approvers).

[docs]: https://opentelemetry.io/docs/demo/
[helm-charts]: https://github.com/open-telemetry/opentelemetry-helm-charts
