### PR TITLE
Bump helm chart version and regenerate

### DIFF
--- a/gcp/helmfile.yaml
+++ b/gcp/helmfile.yaml
@@ -32,7 +32,7 @@ releases:
   - name: opentelemetry-demo
     namespace: "{{ .Values.namespace }}"
     chart: open-telemetry/opentelemetry-demo
-    version: ~0.32
+    version: ~0.37.8
     values:
       - opentelemetry-demo-values.yaml
       - opentelemetry-demo-features.yaml.gotmpl

--- a/gcp/opentelemetry-demo-values.yaml
+++ b/gcp/opentelemetry-demo-values.yaml
@@ -27,7 +27,7 @@ jaeger:
   enabled: false
 
 components:
-  frontendProxy:
+  frontend-proxy:
     service:
       type: LoadBalancer
       annotations:

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -11,12 +11,13 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: opentelemetry-demo-otelcol
+  name: otel-collector
   namespace: otel-demo
   labels:
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "0.108.0"
+    app.kubernetes.io/version: "0.131.0"
+    app.kubernetes.io/component: standalone-collector
 ---
 # Source: opentelemetry-demo/templates/serviceaccount.yaml
 apiVersion: v1
@@ -25,23 +26,21 @@ metadata:
   name: opentelemetry-demo
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/version: "1.11.1"
+    
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 ---
 # Source: opentelemetry-demo/charts/opentelemetry-collector/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: opentelemetry-demo-otelcol
+  name: otel-collector
   namespace: otel-demo
   labels:
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "0.108.0"
-    
+    app.kubernetes.io/version: "0.131.0"
+    app.kubernetes.io/component: standalone-collector
 data:
   relay: |
     connectors:
@@ -63,7 +62,8 @@ data:
       filter/too_frequent:
         metrics:
           metric:
-          - (IsMatch(name, "(.*)app_currency(.*)")) or (resource.attributes["service.name"] == "flagd")
+          - (IsMatch(name, "(.*)app_currency(.*)")) or (resource.attributes["service.name"]
+            == "flagd")
       k8sattributes:
         extract:
           metadata:
@@ -77,8 +77,6 @@ data:
           - k8s.pod.name
           - k8s.pod.uid
           - k8s.pod.start_time
-        filter:
-          namespace: otel-demo
         passthrough: false
         pod_association:
         - sources:
@@ -126,9 +124,9 @@ data:
           - set(attributes["exported_project_id"], attributes["project_id"])
           - delete_key(attributes, "project_id")
     receivers:
-      httpcheck/frontendproxy:
+      httpcheck/frontend-proxy:
         targets:
-        - endpoint: http://opentelemetry-demo-frontendproxy:8080
+        - endpoint: http://frontend-proxy:8080
       jaeger:
         protocols:
           grpc:
@@ -155,6 +153,9 @@ data:
             static_configs:
             - targets:
               - ${env:MY_POD_IP}:8888
+      redis:
+        collection_interval: 10s
+        endpoint: valkey-cart:6379
       zipkin:
         endpoint: ${env:MY_POD_IP}:9411
     service:
@@ -199,21 +200,27 @@ data:
           - jaeger
           - zipkin
       telemetry:
+        logs:
+          encoding: json
         metrics:
-          address: ${env:MY_POD_IP}:8888
+          level: detailed
+          readers:
+          - periodic:
+              exporter:
+                otlp:
+                  endpoint: ${env:MY_POD_IP}:4317
+                  protocol: grpc/protobuf
 ---
 # Source: opentelemetry-demo/templates/flagd-config.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: opentelemetry-demo-flagd-config
+  name: flagd-config
   namespace: otel-demo
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/name: opentelemetry-demo
-    app.kubernetes.io/version: "1.11.1"
+    
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 data:
   
@@ -230,7 +237,7 @@ data:
           },
           "defaultVariant": "off"
         },
-        "recommendationServiceCacheFailure": {
+        "recommendationCacheFailure": {
           "description": "Fail recommendation service cache",
           "state": "ENABLED",
           "variants": {
@@ -239,7 +246,7 @@ data:
           },
           "defaultVariant": "off"
         },
-        "adServiceManualGc": {
+        "adManualGc": {
           "description": "Triggers full manual garbage collections in the ad service",
           "state": "ENABLED",
           "variants": {
@@ -248,7 +255,7 @@ data:
           },
           "defaultVariant": "off"
         },
-        "adServiceHighCpu": {
+        "adHighCpu": {
           "description": "Triggers high cpu load in the ad service",
           "state": "ENABLED",
           "variants": {
@@ -257,7 +264,7 @@ data:
           },
           "defaultVariant": "off"
         },
-        "adServiceFailure": {
+        "adFailure": {
           "description": "Fail ad service",
           "state": "ENABLED",
           "variants": {
@@ -275,7 +282,7 @@ data:
           },
           "defaultVariant": "off"
         },
-        "cartServiceFailure": {
+        "cartFailure": {
           "description": "Fail cart service",
           "state": "ENABLED",
           "variants": {
@@ -284,16 +291,21 @@ data:
           },
           "defaultVariant": "off"
         },
-        "paymentServiceFailure": {
-          "description": "Fail payment service charge requests",
+        "paymentFailure": {
+          "description": "Fail payment service charge requests n%",
           "state": "ENABLED",
           "variants": {
-            "on": true,
-            "off": false
+            "100%": 1,
+            "90%": 0.95,
+            "75%": 0.75,
+            "50%": 0.5,
+            "25%": 0.25,
+            "10%": 0.1,
+            "off": 0
           },
           "defaultVariant": "off"
         },
-        "paymentServiceUnreachable": {
+        "paymentUnreachable": {
           "description": "Payment service is unavailable",
           "state": "ENABLED",
           "variants": {
@@ -302,7 +314,7 @@ data:
           },
           "defaultVariant": "off"
         },
-        "loadgeneratorFloodHomepage": {
+        "loadGeneratorFloodHomepage": {
           "description": "Flood the frontend with a large amount of requests.",
           "state": "ENABLED",
           "variants": {
@@ -324,16 +336,181 @@ data:
       }
     }
 ---
+# Source: opentelemetry-demo/templates/product-catalog-products.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: product-catalog-products
+  namespace: otel-demo
+  labels:
+    
+    
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/part-of: opentelemetry-demo
+data:
+  
+  products.json: |
+    {
+      "products": [
+        {
+          "id": "OLJCESPC7Z",
+          "name": "National Park Foundation Explorascope",
+          "description": "The National Park Foundation’s (NPF) Explorascope 60AZ is a manual alt-azimuth, refractor telescope perfect for celestial viewing on the go. The NPF Explorascope 60 can view the planets, moon, star clusters and brighter deep sky objects like the Orion Nebula and Andromeda Galaxy.",
+          "picture": "NationalParkFoundationExplorascope.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 101,
+            "nanos": 960000000
+          },
+          "categories": [
+            "telescopes"
+          ]
+        },
+        {
+          "id": "66VCHSJNUP",
+          "name": "Starsense Explorer Refractor Telescope",
+          "description": "The first telescope that uses your smartphone to analyze the night sky and calculate its position in real time. StarSense Explorer is ideal for beginners thanks to the app’s user-friendly interface and detailed tutorials. It’s like having your own personal tour guide of the night sky",
+          "picture": "StarsenseExplorer.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 349,
+            "nanos": 950000000
+          },
+          "categories": [
+            "telescopes"
+          ]
+        },
+        {
+          "id": "1YMWWN1N4O",
+          "name": "Eclipsmart Travel Refractor Telescope",
+          "description": "Dedicated white-light solar scope for the observer on the go. The 50mm refracting solar scope uses Solar Safe, ISO compliant, full-aperture glass filter material to ensure the safest view of solar events.  The kit comes complete with everything you need, including the dedicated travel solar scope, a Solar Safe finderscope, tripod, a high quality 20mm (18x) Kellner eyepiece and a nylon backpack to carry everything in.  This Travel Solar Scope makes it easy to share the Sun as well as partial and total solar eclipses with the whole family and offers much higher magnifications than you would otherwise get using handheld solar viewers or binoculars.",
+          "picture": "EclipsmartTravelRefractorTelescope.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 129,
+            "nanos": 950000000
+          },
+          "categories": [
+            "telescopes",
+            "travel"
+          ]
+        },
+        {
+          "id": "L9ECAV7KIM",
+          "name": "Lens Cleaning Kit",
+          "description": "Wipe away dust, dirt, fingerprints and other particles on your lenses to see clearly with the Lens Cleaning Kit. This cleaning kit works on all glass and optical surfaces, including telescopes, binoculars, spotting scopes, monoculars, microscopes, and even your camera lenses, computer screens, and mobile devices.  The kit comes complete with a retractable lens brush to remove dust particles and dirt and two options to clean smudges and fingerprints off of your optics, pre-moistened lens wipes and a bottled lens cleaning fluid with soft cloth.",
+          "picture": "LensCleaningKit.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 21,
+            "nanos": 950000000
+          },
+          "categories": [
+            "accessories"
+          ]
+        },
+        {
+          "id": "2ZYFJ3GM2N",
+          "name": "Roof Binoculars",
+          "description": "This versatile, all-around binocular is a great choice for the trail, the stadium, the arena, or just about anywhere you want a close-up view of the action without sacrificing brightness or detail. It’s an especially great companion for nature observation and bird watching, with ED glass that helps you spot the subtlest field markings and a close focus of just 6.5 feet.",
+          "picture": "RoofBinoculars.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 209,
+            "nanos": 950000000
+          },
+          "categories": [
+            "binoculars"
+          ]
+        },
+        {
+          "id": "0PUK6V6EV0",
+          "name": "Solar System Color Imager",
+          "description": "You have your new telescope and have observed Saturn and Jupiter. Now you're ready to take the next step and start imaging them. But where do you begin? The NexImage 10 Solar System Imager is the perfect solution.",
+          "picture": "SolarSystemColorImager.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 175,
+            "nanos": 0
+          },
+          "categories": [
+            "accessories",
+            "telescopes"
+          ]
+        },
+        {
+          "id": "LS4PSXUNUM",
+          "name": "Red Flashlight",
+          "description": "This 3-in-1 device features a 3-mode red flashlight, a hand warmer, and a portable power bank for recharging your personal electronics on the go. Whether you use it to light the way at an astronomy star party, a night walk, or wildlife research, ThermoTorch 3 Astro Red’s rugged, IPX4-rated design will withstand your everyday activities.",
+          "picture": "RedFlashlight.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 57,
+            "nanos": 80000000
+          },
+          "categories": [
+            "accessories",
+            "flashlights"
+          ]
+        },
+        {
+          "id": "9SIQT8TOJO",
+          "name": "Optical Tube Assembly",
+          "description": "Capturing impressive deep-sky astroimages is easier than ever with Rowe-Ackermann Schmidt Astrograph (RASA) V2, the perfect companion to today’s top DSLR or astronomical CCD cameras. This fast, wide-field f/2.2 system allows for shorter exposure times compared to traditional f/10 astroimaging, without sacrificing resolution. Because shorter sub-exposure times are possible, your equatorial mount won’t need to accurately track over extended periods. The short focal length also lessens equatorial tracking demands. In many cases, autoguiding will not be required.",
+          "picture": "OpticalTubeAssembly.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 3599,
+            "nanos": 0
+          },
+          "categories": [
+            "accessories",
+            "telescopes",
+            "assembly"
+          ]
+        },
+        {
+          "id": "6E92ZMYYFZ",
+          "name": "Solar Filter",
+          "description": "Enhance your viewing experience with EclipSmart Solar Filter for 8” telescopes. With two Velcro straps and four self-adhesive Velcro pads for added safety, you can be assured that the solar filter cannot be accidentally knocked off and will provide Solar Safe, ISO compliant viewing.",
+          "picture": "SolarFilter.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 69,
+            "nanos": 950000000
+          },
+          "categories": [
+            "accessories",
+            "telescopes"
+          ]
+        },
+        {
+          "id": "HQTGWGPNH4",
+          "name": "The Comet Book",
+          "description": "A 16th-century treatise on comets, created anonymously in Flanders (now northern France) and now held at the Universitätsbibliothek Kassel. Commonly known as The Comet Book (or Kometenbuch in German), its full title translates as “Comets and their General and Particular Meanings, According to Ptolomeé, Albumasar, Haly, Aliquind and other Astrologers”. The image is from https://publicdomainreview.org/collection/the-comet-book, made available by the Universitätsbibliothek Kassel under a CC-BY SA 4.0 license (https://creativecommons.org/licenses/by-sa/4.0/)",
+          "picture": "TheCometBook.jpg",
+          "priceUsd": {
+            "currencyCode": "USD",
+            "units": 0,
+            "nanos": 990000000
+          },
+          "categories": [
+            "books"
+          ]
+        }
+      ]
+    }
+---
 # Source: opentelemetry-demo/charts/opentelemetry-collector/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: opentelemetry-demo-otelcol
+  name: otel-collector
   labels:
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "0.108.0"
-    
+    app.kubernetes.io/version: "0.131.0"
+    app.kubernetes.io/component: standalone-collector
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces"]
@@ -349,32 +526,32 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: opentelemetry-demo-otelcol
+  name: otel-collector
   labels:
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "0.108.0"
-    
+    app.kubernetes.io/version: "0.131.0"
+    app.kubernetes.io/component: standalone-collector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: opentelemetry-demo-otelcol
+  name: otel-collector
 subjects:
 - kind: ServiceAccount
-  name: opentelemetry-demo-otelcol
+  name: otel-collector
   namespace: otel-demo
 ---
 # Source: opentelemetry-demo/charts/opentelemetry-collector/templates/service.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-otelcol
+  name: otel-collector
   namespace: otel-demo
   labels:
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "0.108.0"
-    
+    app.kubernetes.io/version: "0.131.0"
+    app.kubernetes.io/component: standalone-collector
     component: standalone-collector
 spec:
   type: ClusterIP
@@ -405,16 +582,12 @@ spec:
       port: 4318
       targetPort: 4318
       protocol: TCP
-    - name: prometheus
-      port: 9464
-      targetPort: 9464
-      protocol: TCP
     - name: zipkin
       port: 9411
       targetPort: 9411
       protocol: TCP
   selector:
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: opentelemetry-demo
     component: standalone-collector
   internalTrafficPolicy: Cluster
@@ -423,14 +596,14 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-adservice
+  name: ad
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-adservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: opentelemetry-demo-adservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: ad
+    
+    app.kubernetes.io/component: ad
+    app.kubernetes.io/name: ad
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -440,20 +613,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-adservice
+    opentelemetry.io/name: ad
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-cartservice
+  name: cart
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-cartservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: opentelemetry-demo-cartservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: cart
+    
+    app.kubernetes.io/component: cart
+    app.kubernetes.io/name: cart
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -463,20 +636,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-cartservice
+    opentelemetry.io/name: cart
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-checkoutservice
+  name: checkout
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-checkoutservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: opentelemetry-demo-checkoutservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: checkout
+    
+    app.kubernetes.io/component: checkout
+    app.kubernetes.io/name: checkout
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -486,20 +659,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-checkoutservice
+    opentelemetry.io/name: checkout
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-currencyservice
+  name: currency
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-currencyservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: opentelemetry-demo-currencyservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: currency
+    
+    app.kubernetes.io/component: currency
+    app.kubernetes.io/name: currency
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -509,20 +682,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-currencyservice
+    opentelemetry.io/name: currency
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-emailservice
+  name: email
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-emailservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: opentelemetry-demo-emailservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: email
+    
+    app.kubernetes.io/component: email
+    app.kubernetes.io/name: email
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -532,43 +705,49 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-emailservice
+    opentelemetry.io/name: email
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-flagd
+  name: flagd
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-flagd
-    app.kubernetes.io/instance: opentelemetry-demo
+    opentelemetry.io/name: flagd
+    
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: opentelemetry-demo-flagd
-    app.kubernetes.io/version: "1.11.1"
+    app.kubernetes.io/name: flagd
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 8013
-      name: tcp-service
+      name: rpc
       targetPort: 8013
+    - port: 8016
+      name: ofrep
+      targetPort: 8016
+    - port: 4000
+      name: tcp-service-0
+      targetPort: 4000
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-flagd
+    opentelemetry.io/name: flagd
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-frontend
+  name: frontend
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-frontend
-    app.kubernetes.io/instance: opentelemetry-demo
+    opentelemetry.io/name: frontend
+    
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: opentelemetry-demo-frontend
-    app.kubernetes.io/version: "1.11.1"
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -578,20 +757,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-frontend
+    opentelemetry.io/name: frontend
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-frontendproxy
+  name: frontend-proxy
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-frontendproxy
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: opentelemetry-demo-frontendproxy
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: frontend-proxy
+    
+    app.kubernetes.io/component: frontend-proxy
+    app.kubernetes.io/name: frontend-proxy
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
   annotations:
     networking.gke.io/internal-load-balancer-allow-global-access: "true"
@@ -604,20 +783,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-frontendproxy
+    opentelemetry.io/name: frontend-proxy
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-imageprovider
+  name: image-provider
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-imageprovider
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: opentelemetry-demo-imageprovider
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: image-provider
+    
+    app.kubernetes.io/component: image-provider
+    app.kubernetes.io/name: image-provider
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -627,20 +806,20 @@ spec:
       targetPort: 8081
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-imageprovider
+    opentelemetry.io/name: image-provider
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-kafka
+  name: kafka
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-kafka
-    app.kubernetes.io/instance: opentelemetry-demo
+    opentelemetry.io/name: kafka
+    
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: opentelemetry-demo-kafka
-    app.kubernetes.io/version: "1.11.1"
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -653,20 +832,20 @@ spec:
       targetPort: 9093
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-kafka
+    opentelemetry.io/name: kafka
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-loadgenerator
+  name: load-generator
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-loadgenerator
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: opentelemetry-demo-loadgenerator
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: load-generator
+    
+    app.kubernetes.io/component: load-generator
+    app.kubernetes.io/name: load-generator
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -676,20 +855,20 @@ spec:
       targetPort: 8089
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-loadgenerator
+    opentelemetry.io/name: load-generator
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-paymentservice
+  name: payment
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-paymentservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: opentelemetry-demo-paymentservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: payment
+    
+    app.kubernetes.io/component: payment
+    app.kubernetes.io/name: payment
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -699,20 +878,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-paymentservice
+    opentelemetry.io/name: payment
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-productcatalogservice
+  name: product-catalog
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-productcatalogservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: opentelemetry-demo-productcatalogservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: product-catalog
+    
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -722,20 +901,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-productcatalogservice
+    opentelemetry.io/name: product-catalog
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-quoteservice
+  name: quote
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-quoteservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: opentelemetry-demo-quoteservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: quote
+    
+    app.kubernetes.io/component: quote
+    app.kubernetes.io/name: quote
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -745,20 +924,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-quoteservice
+    opentelemetry.io/name: quote
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-recommendationservice
+  name: recommendation
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-recommendationservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: opentelemetry-demo-recommendationservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: recommendation
+    
+    app.kubernetes.io/component: recommendation
+    app.kubernetes.io/name: recommendation
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -768,20 +947,20 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-recommendationservice
+    opentelemetry.io/name: recommendation
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-shippingservice
+  name: shipping
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-shippingservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: opentelemetry-demo-shippingservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: shipping
+    
+    app.kubernetes.io/component: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
@@ -791,48 +970,48 @@ spec:
       targetPort: 8080
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-shippingservice
+    opentelemetry.io/name: shipping
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentelemetry-demo-valkey
+  name: valkey-cart
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-valkey
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: opentelemetry-demo-valkey
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: valkey-cart
+    
+    app.kubernetes.io/component: valkey-cart
+    app.kubernetes.io/name: valkey-cart
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   type: ClusterIP
   ports:
     - port: 6379
-      name: valkey
+      name: valkey-cart
       targetPort: 6379
   selector:
     
-    opentelemetry.io/name: opentelemetry-demo-valkey
+    opentelemetry.io/name: valkey-cart
 ---
 # Source: opentelemetry-demo/charts/opentelemetry-collector/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-otelcol
+  name: otel-collector
   namespace: otel-demo
   labels:
-    app.kubernetes.io/name: otelcol
+    app.kubernetes.io/name: opentelemetry-collector
     app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/version: "0.108.0"
-    
+    app.kubernetes.io/version: "0.131.0"
+    app.kubernetes.io/component: standalone-collector
 spec:
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/name: otelcol
+      app.kubernetes.io/name: opentelemetry-collector
       app.kubernetes.io/instance: opentelemetry-demo
       component: standalone-collector
   strategy:
@@ -840,18 +1019,18 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e97c80b05446f6f5618296306bb6dbc2f24010ca9bda1c6e2716d17d27c94c44
+        checksum/config: f3cf0587b803d273ffaeb0fa1ec88e8c8672a73cf93eb1940363fb29bb84344b
         opentelemetry_community_demo: "true"
-        prometheus.io/port: "9464"
         prometheus.io/scrape: "true"
       labels:
-        app.kubernetes.io/name: otelcol
+        app.kubernetes.io/name: opentelemetry-collector
         app.kubernetes.io/instance: opentelemetry-demo
         component: standalone-collector
         
     spec:
       
-      serviceAccountName: opentelemetry-demo-otelcol
+      serviceAccountName: otel-collector
+      automountServiceAccountToken: true
       securityContext:
         {}
       containers:
@@ -860,7 +1039,7 @@ spec:
             - --config=/conf/relay.yaml
           securityContext:
             {}
-          image: "otel/opentelemetry-collector-contrib:0.108.0"
+          image: "otel/opentelemetry-collector-contrib:0.131.0"
           imagePullPolicy: IfNotPresent
           ports:
             
@@ -881,9 +1060,6 @@ spec:
               protocol: TCP
             - name: otlp-http
               containerPort: 4318
-              protocol: TCP
-            - name: prometheus
-              containerPort: 9464
               protocol: TCP
             - name: zipkin
               containerPort: 9411
@@ -913,7 +1089,7 @@ spec:
       volumes:
         - name: opentelemetry-collector-configmap
           configMap:
-            name: opentelemetry-demo-otelcol
+            name: otel-collector
             items:
               - key: relay
                 path: relay.yaml
@@ -923,14 +1099,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-accountingservice
+  name: accounting
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-accountingservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: accountingservice
-    app.kubernetes.io/name: opentelemetry-demo-accountingservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: accounting
+    
+    app.kubernetes.io/component: accounting
+    app.kubernetes.io/name: accounting
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -938,63 +1114,62 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-accountingservice
+      opentelemetry.io/name: accounting
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-accountingservice
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: accountingservice
-        app.kubernetes.io/name: opentelemetry-demo-accountingservice
+        opentelemetry.io/name: accounting
+        
+        app.kubernetes.io/component: accounting
+        app.kubernetes.io/name: accounting
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: accountingservice
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-accountingservice'
+        - name: accounting
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-accounting'
           imagePullPolicy: IfNotPresent
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: KAFKA_SERVICE_ADDR
-            value: 'opentelemetry-demo-kafka:9092'
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: KAFKA_ADDR
+              value: kafka:9092
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4318
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 120Mi
           volumeMounts:
-      volumes:
       initContainers:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 opentelemetry-demo-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
+      volumes:
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-adservice
+  name: ad
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-adservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: adservice
-    app.kubernetes.io/name: opentelemetry-demo-adservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: ad
+    
+    app.kubernetes.io/component: ad
+    app.kubernetes.io/name: ad
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1002,47 +1177,47 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-adservice
+      opentelemetry.io/name: ad
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-adservice
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: adservice
-        app.kubernetes.io/name: opentelemetry-demo-adservice
+        opentelemetry.io/name: ad
+        
+        app.kubernetes.io/component: ad
+        app.kubernetes.io/name: ad
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: adservice
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-adservice'
+        - name: ad
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-ad'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8080
-            name: service
+            
+            - containerPort: 8080
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: AD_SERVICE_PORT
-            value: "8080"
-          - name: FLAGD_HOST
-            value: 'opentelemetry-demo-flagd'
-          - name: FLAGD_PORT
-            value: "8013"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318
-          - name: OTEL_LOGS_EXPORTER
-            value: otlp
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: AD_PORT
+              value: "8080"
+            - name: FLAGD_HOST
+              value: flagd
+            - name: FLAGD_PORT
+              value: "8013"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4318
+            - name: OTEL_LOGS_EXPORTER
+              value: otlp
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 300Mi
@@ -1053,14 +1228,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-cartservice
+  name: cart
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-cartservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: cartservice
-    app.kubernetes.io/name: opentelemetry-demo-cartservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: cart
+    
+    app.kubernetes.io/component: cart
+    app.kubernetes.io/name: cart
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1068,75 +1243,75 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-cartservice
+      opentelemetry.io/name: cart
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-cartservice
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: cartservice
-        app.kubernetes.io/name: opentelemetry-demo-cartservice
+        opentelemetry.io/name: cart
+        
+        app.kubernetes.io/component: cart
+        app.kubernetes.io/name: cart
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: cartservice
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-cartservice'
+        - name: cart
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-cart'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8080
-            name: service
+            
+            - containerPort: 8080
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: CART_SERVICE_PORT
-            value: "8080"
-          - name: ASPNETCORE_URLS
-            value: http://*:$(CART_SERVICE_PORT)
-          - name: VALKEY_ADDR
-            value: 'opentelemetry-demo-valkey:6379'
-          - name: FLAGD_HOST
-            value: 'opentelemetry-demo-flagd'
-          - name: FLAGD_PORT
-            value: "8013"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: CART_PORT
+              value: "8080"
+            - name: ASPNETCORE_URLS
+              value: http://*:$(CART_PORT)
+            - name: VALKEY_ADDR
+              value: valkey-cart:6379
+            - name: FLAGD_HOST
+              value: flagd
+            - name: FLAGD_PORT
+              value: "8013"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 160Mi
           volumeMounts:
-      volumes:
       initContainers:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 opentelemetry-demo-valkey 6379; do echo waiting
-            for valkey; sleep 2; done;
+          - until nc -z -v -w30 valkey-cart 6379; do echo waiting for valkey-cart; sleep 2;
+            done;
           image: busybox:latest
-          name: wait-for-valkey
+          name: wait-for-valkey-cart
+      volumes:
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-checkoutservice
+  name: checkout
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-checkoutservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: checkoutservice
-    app.kubernetes.io/name: opentelemetry-demo-checkoutservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: checkout
+    
+    app.kubernetes.io/component: checkout
+    app.kubernetes.io/name: checkout
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1144,85 +1319,84 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-checkoutservice
+      opentelemetry.io/name: checkout
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-checkoutservice
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: checkoutservice
-        app.kubernetes.io/name: opentelemetry-demo-checkoutservice
+        opentelemetry.io/name: checkout
+        
+        app.kubernetes.io/component: checkout
+        app.kubernetes.io/name: checkout
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: checkoutservice
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-checkoutservice'
+        - name: checkout
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-checkout'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8080
-            name: service
+            
+            - containerPort: 8080
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: CHECKOUT_SERVICE_PORT
-            value: "8080"
-          - name: CART_SERVICE_ADDR
-            value: 'opentelemetry-demo-cartservice:8080'
-          - name: CURRENCY_SERVICE_ADDR
-            value: 'opentelemetry-demo-currencyservice:8080'
-          - name: EMAIL_SERVICE_ADDR
-            value: http://opentelemetry-demo-emailservice:8080
-          - name: PAYMENT_SERVICE_ADDR
-            value: 'opentelemetry-demo-paymentservice:8080'
-          - name: PRODUCT_CATALOG_SERVICE_ADDR
-            value: 'opentelemetry-demo-productcatalogservice:8080'
-          - name: SHIPPING_SERVICE_ADDR
-            value: 'opentelemetry-demo-shippingservice:8080'
-          - name: KAFKA_SERVICE_ADDR
-            value: 'opentelemetry-demo-kafka:9092'
-          - name: FLAGD_HOST
-            value: 'opentelemetry-demo-flagd'
-          - name: FLAGD_PORT
-            value: "8013"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: CHECKOUT_PORT
+              value: "8080"
+            - name: CART_ADDR
+              value: cart:8080
+            - name: CURRENCY_ADDR
+              value: currency:8080
+            - name: EMAIL_ADDR
+              value: http://email:8080
+            - name: PAYMENT_ADDR
+              value: payment:8080
+            - name: PRODUCT_CATALOG_ADDR
+              value: product-catalog:8080
+            - name: SHIPPING_ADDR
+              value: shipping:8080
+            - name: KAFKA_ADDR
+              value: kafka:9092
+            - name: FLAGD_HOST
+              value: flagd
+            - name: FLAGD_PORT
+              value: "8013"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
           volumeMounts:
-      volumes:
       initContainers:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 opentelemetry-demo-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
           image: busybox:latest
           name: wait-for-kafka
+      volumes:
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-currencyservice
+  name: currency
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-currencyservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: currencyservice
-    app.kubernetes.io/name: opentelemetry-demo-currencyservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: currency
+    
+    app.kubernetes.io/component: currency
+    app.kubernetes.io/name: currency
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1230,43 +1404,43 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-currencyservice
+      opentelemetry.io/name: currency
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-currencyservice
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: currencyservice
-        app.kubernetes.io/name: opentelemetry-demo-currencyservice
+        opentelemetry.io/name: currency
+        
+        app.kubernetes.io/component: currency
+        app.kubernetes.io/name: currency
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: currencyservice
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-currencyservice'
+        - name: currency
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-currency'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8080
-            name: service
+            
+            - containerPort: 8080
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: CURRENCY_SERVICE_PORT
-            value: "8080"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: VERSION
-            value: '1.11.1'
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: CURRENCY_PORT
+              value: "8080"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: VERSION
+              value: '2.0.2'
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -1277,14 +1451,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-emailservice
+  name: email
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-emailservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: emailservice
-    app.kubernetes.io/name: opentelemetry-demo-emailservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: email
+    
+    app.kubernetes.io/component: email
+    app.kubernetes.io/name: email
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1292,43 +1466,43 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-emailservice
+      opentelemetry.io/name: email
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-emailservice
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: emailservice
-        app.kubernetes.io/name: opentelemetry-demo-emailservice
+        opentelemetry.io/name: email
+        
+        app.kubernetes.io/component: email
+        app.kubernetes.io/name: email
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: emailservice
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-emailservice'
+        - name: email
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-email'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8080
-            name: service
+            
+            - containerPort: 8080
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: EMAIL_SERVICE_PORT
-            value: "8080"
-          - name: APP_ENV
-            value: production
-          - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: EMAIL_PORT
+              value: "8080"
+            - name: APP_ENV
+              value: production
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4318/v1/traces
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 100Mi
@@ -1339,14 +1513,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-flagd
+  name: flagd
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-flagd
-    app.kubernetes.io/instance: opentelemetry-demo
+    opentelemetry.io/name: flagd
+    
     app.kubernetes.io/component: flagd
-    app.kubernetes.io/name: opentelemetry-demo-flagd
-    app.kubernetes.io/version: "1.11.1"
+    app.kubernetes.io/name: flagd
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1354,137 +1528,118 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-flagd
+      opentelemetry.io/name: flagd
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-flagd
-        app.kubernetes.io/instance: opentelemetry-demo
+        opentelemetry.io/name: flagd
+        
         app.kubernetes.io/component: flagd
-        app.kubernetes.io/name: opentelemetry-demo-flagd
+        app.kubernetes.io/name: flagd
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: flagd
-          image: 'ghcr.io/open-feature/flagd:v0.11.1'
+          image: 'ghcr.io/open-feature/flagd:v0.12.8'
           imagePullPolicy: IfNotPresent
           command:
-          - /flagd-build
-          - start
-          - --uri
-          - file:./etc/flagd/demo.flagd.json
+            - /flagd-build
+            - start
+            - --port
+            - "8013"
+            - --ofrep-port
+            - "8016"
+            - --uri
+            - file:./etc/flagd/demo.flagd.json
           ports:
-          
-          - containerPort: 8013
-            name: service
+            
+            - containerPort: 8013
+              name: rpc
+            - containerPort: 8016
+              name: ofrep
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: FLAGD_METRICS_EXPORTER
-            value: otel
-          - name: FLAGD_OTEL_COLLECTOR_URI
-            value: $(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: FLAGD_METRICS_EXPORTER
+              value: otel
+            - name: FLAGD_OTEL_COLLECTOR_URI
+              value: $(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
-              memory: 50Mi
+              memory: 75Mi
           volumeMounts:
-            - name: config
+            - name: config-rw
               mountPath: /etc/flagd
-      volumes:
-        - name: config
-          configMap:
-            name: opentelemetry-demo-flagd-config
----
-# Source: opentelemetry-demo/templates/component.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: opentelemetry-demo-frauddetectionservice
-  labels:
-    
-    opentelemetry.io/name: opentelemetry-demo-frauddetectionservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: frauddetectionservice
-    app.kubernetes.io/name: opentelemetry-demo-frauddetectionservice
-    app.kubernetes.io/version: "1.11.1"
-    app.kubernetes.io/part-of: opentelemetry-demo
-spec:
-  replicas: 1
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      
-      opentelemetry.io/name: opentelemetry-demo-frauddetectionservice
-  template:
-    metadata:
-      labels:
-        
-        opentelemetry.io/name: opentelemetry-demo-frauddetectionservice
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: frauddetectionservice
-        app.kubernetes.io/name: opentelemetry-demo-frauddetectionservice
-    spec:
-      serviceAccountName: opentelemetry-demo
-      containers:
-        - name: frauddetectionservice
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-frauddetectionservice'
+        - name: flagd-ui
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-flagd-ui'
           imagePullPolicy: IfNotPresent
+          ports:
+            
+            - containerPort: 4000
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: KAFKA_SERVICE_ADDR
-            value: 'opentelemetry-demo-kafka:9092'
-          - name: FLAGD_HOST
-            value: 'opentelemetry-demo-flagd'
-          - name: FLAGD_PORT
-            value: "8013"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: FLAGD_METRICS_EXPORTER
+              value: otel
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4318
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
-              memory: 300Mi
+              memory: 100Mi
           volumeMounts:
-      volumes:
+            - mountPath: /app/data
+              name: config-rw
       initContainers:
         - command:
           - sh
           - -c
-          - until nc -z -v -w30 opentelemetry-demo-kafka 9092; do echo waiting
-            for kafka; sleep 2; done;
-          image: busybox:latest
-          name: wait-for-kafka
+          - cp /config-ro/demo.flagd.json /config-rw/demo.flagd.json && cat /config-rw/demo.flagd.json
+          image: busybox
+          name: init-config
+          volumeMounts:
+          - mountPath: /config-ro
+            name: config-ro
+          - mountPath: /config-rw
+            name: config-rw
+      volumes:
+        - name: config-rw
+          emptyDir: {}
+        - configMap:
+            name: flagd-config
+          name: config-ro
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-frontend
+  name: fraud-detection
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-frontend
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: frontend
-    app.kubernetes.io/name: opentelemetry-demo-frontend
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: fraud-detection
+    
+    app.kubernetes.io/component: fraud-detection
+    app.kubernetes.io/name: fraud-detection
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1492,67 +1647,134 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-frontend
+      opentelemetry.io/name: fraud-detection
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-frontend
-        app.kubernetes.io/instance: opentelemetry-demo
+        opentelemetry.io/name: fraud-detection
+        
+        app.kubernetes.io/component: fraud-detection
+        app.kubernetes.io/name: fraud-detection
+    spec:
+      serviceAccountName: opentelemetry-demo
+      containers:
+        - name: fraud-detection
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-fraud-detection'
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: KAFKA_ADDR
+              value: kafka:9092
+            - name: FLAGD_HOST
+              value: flagd
+            - name: FLAGD_PORT
+              value: "8013"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4318
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
+          resources:
+            limits:
+              memory: 300Mi
+          volumeMounts:
+      initContainers:
+        - command:
+          - sh
+          - -c
+          - until nc -z -v -w30 kafka 9092; do echo waiting for kafka; sleep 2; done;
+          image: busybox:latest
+          name: wait-for-kafka
+      volumes:
+---
+# Source: opentelemetry-demo/templates/component.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    
+    opentelemetry.io/name: frontend
+    
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/name: frontend
+    app.kubernetes.io/version: "2.0.2"
+    app.kubernetes.io/part-of: opentelemetry-demo
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      
+      opentelemetry.io/name: frontend
+  template:
+    metadata:
+      labels:
+        
+        opentelemetry.io/name: frontend
+        
         app.kubernetes.io/component: frontend
-        app.kubernetes.io/name: opentelemetry-demo-frontend
+        app.kubernetes.io/name: frontend
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: frontend
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-frontend'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8080
-            name: service
+            
+            - containerPort: 8080
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: FRONTEND_PORT
-            value: "8080"
-          - name: FRONTEND_ADDR
-            value: :8080
-          - name: AD_SERVICE_ADDR
-            value: 'opentelemetry-demo-adservice:8080'
-          - name: CART_SERVICE_ADDR
-            value: 'opentelemetry-demo-cartservice:8080'
-          - name: CHECKOUT_SERVICE_ADDR
-            value: 'opentelemetry-demo-checkoutservice:8080'
-          - name: CURRENCY_SERVICE_ADDR
-            value: 'opentelemetry-demo-currencyservice:8080'
-          - name: PRODUCT_CATALOG_SERVICE_ADDR
-            value: 'opentelemetry-demo-productcatalogservice:8080'
-          - name: RECOMMENDATION_SERVICE_ADDR
-            value: 'opentelemetry-demo-recommendationservice:8080'
-          - name: SHIPPING_SERVICE_ADDR
-            value: 'opentelemetry-demo-shippingservice:8080'
-          - name: FLAGD_HOST
-            value: 'opentelemetry-demo-flagd'
-          - name: FLAGD_PORT
-            value: "8013"
-          - name: OTEL_COLLECTOR_HOST
-            value: $(OTEL_COLLECTOR_NAME)
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: WEB_OTEL_SERVICE_NAME
-            value: frontend-web
-          - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-            value: http://localhost:8080/otlp-http/v1/traces
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: FRONTEND_PORT
+              value: "8080"
+            - name: FRONTEND_ADDR
+              value: :8080
+            - name: AD_ADDR
+              value: ad:8080
+            - name: CART_ADDR
+              value: cart:8080
+            - name: CHECKOUT_ADDR
+              value: checkout:8080
+            - name: CURRENCY_ADDR
+              value: currency:8080
+            - name: PRODUCT_CATALOG_ADDR
+              value: product-catalog:8080
+            - name: RECOMMENDATION_ADDR
+              value: recommendation:8080
+            - name: SHIPPING_ADDR
+              value: shipping:8080
+            - name: FLAGD_HOST
+              value: flagd
+            - name: FLAGD_PORT
+              value: "8013"
+            - name: OTEL_COLLECTOR_HOST
+              value: $(OTEL_COLLECTOR_NAME)
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: WEB_OTEL_SERVICE_NAME
+              value: frontend-web
+            - name: PUBLIC_OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: http://localhost:8080/otlp-http/v1/traces
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 250Mi
@@ -1567,14 +1789,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-frontendproxy
+  name: frontend-proxy
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-frontendproxy
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: frontendproxy
-    app.kubernetes.io/name: opentelemetry-demo-frontendproxy
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: frontend-proxy
+    
+    app.kubernetes.io/component: frontend-proxy
+    app.kubernetes.io/name: frontend-proxy
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1582,72 +1804,76 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-frontendproxy
+      opentelemetry.io/name: frontend-proxy
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-frontendproxy
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: frontendproxy
-        app.kubernetes.io/name: opentelemetry-demo-frontendproxy
+        opentelemetry.io/name: frontend-proxy
+        
+        app.kubernetes.io/component: frontend-proxy
+        app.kubernetes.io/name: frontend-proxy
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: frontendproxy
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-frontendproxy'
+        - name: frontend-proxy
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-frontend-proxy'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8080
-            name: service
+            
+            - containerPort: 8080
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: ENVOY_PORT
-            value: "8080"
-          - name: FLAGD_HOST
-            value: 'opentelemetry-demo-flagd'
-          - name: FLAGD_PORT
-            value: "8013"
-          - name: FRONTEND_HOST
-            value: 'opentelemetry-demo-frontend'
-          - name: FRONTEND_PORT
-            value: "8080"
-          - name: GRAFANA_SERVICE_HOST
-            value: 'opentelemetry-demo-grafana'
-          - name: GRAFANA_SERVICE_PORT
-            value: "80"
-          - name: IMAGE_PROVIDER_HOST
-            value: 'opentelemetry-demo-imageprovider'
-          - name: IMAGE_PROVIDER_PORT
-            value: "8081"
-          - name: JAEGER_SERVICE_HOST
-            value: 'opentelemetry-demo-jaeger-query'
-          - name: JAEGER_SERVICE_PORT
-            value: "16686"
-          - name: LOCUST_WEB_HOST
-            value: 'opentelemetry-demo-loadgenerator'
-          - name: LOCUST_WEB_PORT
-            value: "8089"
-          - name: OTEL_COLLECTOR_HOST
-            value: $(OTEL_COLLECTOR_NAME)
-          - name: OTEL_COLLECTOR_PORT_GRPC
-            value: "4317"
-          - name: OTEL_COLLECTOR_PORT_HTTP
-            value: "4318"
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: ENVOY_PORT
+              value: "8080"
+            - name: FLAGD_HOST
+              value: flagd
+            - name: FLAGD_PORT
+              value: "8013"
+            - name: FLAGD_UI_HOST
+              value: flagd
+            - name: FLAGD_UI_PORT
+              value: "4000"
+            - name: FRONTEND_HOST
+              value: frontend
+            - name: FRONTEND_PORT
+              value: "8080"
+            - name: GRAFANA_HOST
+              value: grafana
+            - name: GRAFANA_PORT
+              value: "80"
+            - name: IMAGE_PROVIDER_HOST
+              value: image-provider
+            - name: IMAGE_PROVIDER_PORT
+              value: "8081"
+            - name: JAEGER_HOST
+              value: jaeger-query
+            - name: JAEGER_PORT
+              value: "16686"
+            - name: LOCUST_WEB_HOST
+              value: load-generator
+            - name: LOCUST_WEB_PORT
+              value: "8089"
+            - name: OTEL_COLLECTOR_HOST
+              value: $(OTEL_COLLECTOR_NAME)
+            - name: OTEL_COLLECTOR_PORT_GRPC
+              value: "4317"
+            - name: OTEL_COLLECTOR_PORT_HTTP
+              value: "4318"
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
-              memory: 50Mi
+              memory: 65Mi
           securityContext:
             runAsGroup: 101
             runAsNonRoot: true
@@ -1659,14 +1885,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-imageprovider
+  name: image-provider
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-imageprovider
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: imageprovider
-    app.kubernetes.io/name: opentelemetry-demo-imageprovider
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: image-provider
+    
+    app.kubernetes.io/component: image-provider
+    app.kubernetes.io/name: image-provider
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1674,43 +1900,43 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-imageprovider
+      opentelemetry.io/name: image-provider
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-imageprovider
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: imageprovider
-        app.kubernetes.io/name: opentelemetry-demo-imageprovider
+        opentelemetry.io/name: image-provider
+        
+        app.kubernetes.io/component: image-provider
+        app.kubernetes.io/name: image-provider
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: imageprovider
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-imageprovider'
+        - name: image-provider
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-image-provider'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8081
-            name: service
+            
+            - containerPort: 8081
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: IMAGE_PROVIDER_PORT
-            value: "8081"
-          - name: OTEL_COLLECTOR_PORT_GRPC
-            value: "4317"
-          - name: OTEL_COLLECTOR_HOST
-            value: $(OTEL_COLLECTOR_NAME)
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: IMAGE_PROVIDER_PORT
+              value: "8081"
+            - name: OTEL_COLLECTOR_PORT_GRPC
+              value: "4317"
+            - name: OTEL_COLLECTOR_HOST
+              value: $(OTEL_COLLECTOR_NAME)
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 50Mi
@@ -1721,14 +1947,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-kafka
+  name: kafka
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-kafka
-    app.kubernetes.io/instance: opentelemetry-demo
+    opentelemetry.io/name: kafka
+    
     app.kubernetes.io/component: kafka
-    app.kubernetes.io/name: opentelemetry-demo-kafka
-    app.kubernetes.io/version: "1.11.1"
+    app.kubernetes.io/name: kafka
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1736,45 +1962,45 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-kafka
+      opentelemetry.io/name: kafka
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-kafka
-        app.kubernetes.io/instance: opentelemetry-demo
+        opentelemetry.io/name: kafka
+        
         app.kubernetes.io/component: kafka
-        app.kubernetes.io/name: opentelemetry-demo-kafka
+        app.kubernetes.io/name: kafka
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
         - name: kafka
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-kafka'
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-kafka'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 9092
-            name: plaintext
-          - containerPort: 9093
-            name: controller
+            
+            - containerPort: 9092
+              name: plaintext
+            - containerPort: 9093
+              name: controller
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: KAFKA_ADVERTISED_LISTENERS
-            value: PLAINTEXT://opentelemetry-demo-kafka:9092
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318
-          - name: KAFKA_HEAP_OPTS
-            value: -Xmx400M -Xms400M
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://kafka:9092
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4318
+            - name: KAFKA_HEAP_OPTS
+              value: -Xmx400M -Xms400M
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 600Mi
@@ -1789,14 +2015,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-loadgenerator
+  name: load-generator
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-loadgenerator
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: loadgenerator
-    app.kubernetes.io/name: opentelemetry-demo-loadgenerator
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: load-generator
+    
+    app.kubernetes.io/component: load-generator
+    app.kubernetes.io/name: load-generator
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1804,62 +2030,64 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-loadgenerator
+      opentelemetry.io/name: load-generator
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-loadgenerator
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: loadgenerator
-        app.kubernetes.io/name: opentelemetry-demo-loadgenerator
+        opentelemetry.io/name: load-generator
+        
+        app.kubernetes.io/component: load-generator
+        app.kubernetes.io/name: load-generator
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: loadgenerator
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-loadgenerator'
+        - name: load-generator
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-load-generator'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8089
-            name: service
+            
+            - containerPort: 8089
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: LOCUST_WEB_PORT
-            value: "8089"
-          - name: LOCUST_USERS
-            value: "10"
-          - name: LOCUST_SPAWN_RATE
-            value: "1"
-          - name: LOCUST_HOST
-            value: http://opentelemetry-demo-frontendproxy:8080
-          - name: LOCUST_HEADLESS
-            value: "false"
-          - name: LOCUST_AUTOSTART
-            value: "true"
-          - name: LOCUST_BROWSER_TRAFFIC_ENABLED
-            value: "true"
-          - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
-            value: python
-          - name: FLAGD_HOST
-            value: 'opentelemetry-demo-flagd'
-          - name: FLAGD_PORT
-            value: "8013"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: LOCUST_WEB_HOST
+              value: 0.0.0.0
+            - name: LOCUST_WEB_PORT
+              value: "8089"
+            - name: LOCUST_USERS
+              value: "10"
+            - name: LOCUST_SPAWN_RATE
+              value: "1"
+            - name: LOCUST_HOST
+              value: http://frontend-proxy:8080
+            - name: LOCUST_HEADLESS
+              value: "false"
+            - name: LOCUST_AUTOSTART
+              value: "true"
+            - name: LOCUST_BROWSER_TRAFFIC_ENABLED
+              value: "true"
+            - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+              value: python
+            - name: FLAGD_HOST
+              value: flagd
+            - name: FLAGD_OFREP_PORT
+              value: "8016"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
-              memory: 1Gi
+              memory: 1500Mi
           volumeMounts:
       volumes:
 ---
@@ -1867,14 +2095,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-paymentservice
+  name: payment
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-paymentservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: paymentservice
-    app.kubernetes.io/name: opentelemetry-demo-paymentservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: payment
+    
+    app.kubernetes.io/component: payment
+    app.kubernetes.io/name: payment
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1882,45 +2110,45 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-paymentservice
+      opentelemetry.io/name: payment
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-paymentservice
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: paymentservice
-        app.kubernetes.io/name: opentelemetry-demo-paymentservice
+        opentelemetry.io/name: payment
+        
+        app.kubernetes.io/component: payment
+        app.kubernetes.io/name: payment
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: paymentservice
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-paymentservice'
+        - name: payment
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-payment'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8080
-            name: service
+            
+            - containerPort: 8080
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: PAYMENT_SERVICE_PORT
-            value: "8080"
-          - name: FLAGD_HOST
-            value: 'opentelemetry-demo-flagd'
-          - name: FLAGD_PORT
-            value: "8013"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: PAYMENT_PORT
+              value: "8080"
+            - name: FLAGD_HOST
+              value: flagd
+            - name: FLAGD_PORT
+              value: "8013"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 120Mi
@@ -1935,14 +2163,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-productcatalogservice
+  name: product-catalog
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-productcatalogservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: productcatalogservice
-    app.kubernetes.io/name: opentelemetry-demo-productcatalogservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: product-catalog
+    
+    app.kubernetes.io/component: product-catalog
+    app.kubernetes.io/name: product-catalog
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -1950,63 +2178,70 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-productcatalogservice
+      opentelemetry.io/name: product-catalog
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-productcatalogservice
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: productcatalogservice
-        app.kubernetes.io/name: opentelemetry-demo-productcatalogservice
+        opentelemetry.io/name: product-catalog
+        
+        app.kubernetes.io/component: product-catalog
+        app.kubernetes.io/name: product-catalog
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: productcatalogservice
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-productcatalogservice'
+        - name: product-catalog
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-product-catalog'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8080
-            name: service
+            
+            - containerPort: 8080
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: PRODUCT_CATALOG_SERVICE_PORT
-            value: "8080"
-          - name: FLAGD_HOST
-            value: 'opentelemetry-demo-flagd'
-          - name: FLAGD_PORT
-            value: "8013"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: PRODUCT_CATALOG_PORT
+              value: "8080"
+            - name: PRODUCT_CATALOG_RELOAD_INTERVAL
+              value: "10"
+            - name: FLAGD_HOST
+              value: flagd
+            - name: FLAGD_PORT
+              value: "8013"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
           volumeMounts:
+            - name: product-catalog-products
+              mountPath: /usr/src/app/products
       volumes:
+        - name: product-catalog-products
+          configMap:
+            name: product-catalog-products
 ---
 # Source: opentelemetry-demo/templates/component.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-quoteservice
+  name: quote
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-quoteservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: quoteservice
-    app.kubernetes.io/name: opentelemetry-demo-quoteservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: quote
+    
+    app.kubernetes.io/component: quote
+    app.kubernetes.io/name: quote
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -2014,43 +2249,43 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-quoteservice
+      opentelemetry.io/name: quote
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-quoteservice
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: quoteservice
-        app.kubernetes.io/name: opentelemetry-demo-quoteservice
+        opentelemetry.io/name: quote
+        
+        app.kubernetes.io/component: quote
+        app.kubernetes.io/name: quote
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: quoteservice
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-quoteservice'
+        - name: quote
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-quote'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8080
-            name: service
+            
+            - containerPort: 8080
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: QUOTE_SERVICE_PORT
-            value: "8080"
-          - name: OTEL_PHP_AUTOLOAD_ENABLED
-            value: "true"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4318
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: QUOTE_PORT
+              value: "8080"
+            - name: OTEL_PHP_AUTOLOAD_ENABLED
+              value: "true"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4318
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 40Mi
@@ -2065,14 +2300,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-recommendationservice
+  name: recommendation
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-recommendationservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: recommendationservice
-    app.kubernetes.io/name: opentelemetry-demo-recommendationservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: recommendation
+    
+    app.kubernetes.io/component: recommendation
+    app.kubernetes.io/name: recommendation
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -2080,51 +2315,51 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-recommendationservice
+      opentelemetry.io/name: recommendation
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-recommendationservice
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: recommendationservice
-        app.kubernetes.io/name: opentelemetry-demo-recommendationservice
+        opentelemetry.io/name: recommendation
+        
+        app.kubernetes.io/component: recommendation
+        app.kubernetes.io/name: recommendation
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: recommendationservice
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-recommendationservice'
+        - name: recommendation
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-recommendation'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8080
-            name: service
+            
+            - containerPort: 8080
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: RECOMMENDATION_SERVICE_PORT
-            value: "8080"
-          - name: PRODUCT_CATALOG_SERVICE_ADDR
-            value: 'opentelemetry-demo-productcatalogservice:8080'
-          - name: OTEL_PYTHON_LOG_CORRELATION
-            value: "true"
-          - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
-            value: python
-          - name: FLAGD_HOST
-            value: 'opentelemetry-demo-flagd'
-          - name: FLAGD_PORT
-            value: "8013"
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: RECOMMENDATION_PORT
+              value: "8080"
+            - name: PRODUCT_CATALOG_ADDR
+              value: product-catalog:8080
+            - name: OTEL_PYTHON_LOG_CORRELATION
+              value: "true"
+            - name: PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION
+              value: python
+            - name: FLAGD_HOST
+              value: flagd
+            - name: FLAGD_PORT
+              value: "8013"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 500Mi
@@ -2135,14 +2370,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-shippingservice
+  name: shipping
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-shippingservice
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: shippingservice
-    app.kubernetes.io/name: opentelemetry-demo-shippingservice
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: shipping
+    
+    app.kubernetes.io/component: shipping
+    app.kubernetes.io/name: shipping
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -2150,43 +2385,43 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-shippingservice
+      opentelemetry.io/name: shipping
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-shippingservice
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: shippingservice
-        app.kubernetes.io/name: opentelemetry-demo-shippingservice
+        opentelemetry.io/name: shipping
+        
+        app.kubernetes.io/component: shipping
+        app.kubernetes.io/name: shipping
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: shippingservice
-          image: 'ghcr.io/open-telemetry/demo:1.11.1-shippingservice'
+        - name: shipping
+          image: 'ghcr.io/open-telemetry/demo:2.0.2-shipping'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 8080
-            name: service
+            
+            - containerPort: 8080
+              name: service
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: SHIPPING_SERVICE_PORT
-            value: "8080"
-          - name: QUOTE_SERVICE_ADDR
-            value: http://opentelemetry-demo-quoteservice:8080
-          - name: OTEL_EXPORTER_OTLP_ENDPOINT
-            value: http://$(OTEL_COLLECTOR_NAME):4317
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: SHIPPING_PORT
+              value: "8080"
+            - name: QUOTE_ADDR
+              value: http://quote:8080
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: http://$(OTEL_COLLECTOR_NAME):4317
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi
@@ -2197,14 +2432,14 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentelemetry-demo-valkey
+  name: valkey-cart
   labels:
     
-    opentelemetry.io/name: opentelemetry-demo-valkey
-    app.kubernetes.io/instance: opentelemetry-demo
-    app.kubernetes.io/component: valkey
-    app.kubernetes.io/name: opentelemetry-demo-valkey
-    app.kubernetes.io/version: "1.11.1"
+    opentelemetry.io/name: valkey-cart
+    
+    app.kubernetes.io/component: valkey-cart
+    app.kubernetes.io/name: valkey-cart
+    app.kubernetes.io/version: "2.0.2"
     app.kubernetes.io/part-of: opentelemetry-demo
 spec:
   replicas: 1
@@ -2212,37 +2447,37 @@ spec:
   selector:
     matchLabels:
       
-      opentelemetry.io/name: opentelemetry-demo-valkey
+      opentelemetry.io/name: valkey-cart
   template:
     metadata:
       labels:
         
-        opentelemetry.io/name: opentelemetry-demo-valkey
-        app.kubernetes.io/instance: opentelemetry-demo
-        app.kubernetes.io/component: valkey
-        app.kubernetes.io/name: opentelemetry-demo-valkey
+        opentelemetry.io/name: valkey-cart
+        
+        app.kubernetes.io/component: valkey-cart
+        app.kubernetes.io/name: valkey-cart
     spec:
       serviceAccountName: opentelemetry-demo
       containers:
-        - name: valkey
+        - name: valkey-cart
           image: 'valkey/valkey:7.2-alpine'
           imagePullPolicy: IfNotPresent
           ports:
-          
-          - containerPort: 6379
-            name: valkey
+            
+            - containerPort: 6379
+              name: valkey-cart
           env:
-          - name: OTEL_SERVICE_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.labels['app.kubernetes.io/component']
-          - name: OTEL_COLLECTOR_NAME
-            value: 'opentelemetry-demo-otelcol'
-          - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-            value: cumulative
-          - name: OTEL_RESOURCE_ATTRIBUTES
-            value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=1.11.1
+            - name: OTEL_SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.labels['app.kubernetes.io/component']
+            - name: OTEL_COLLECTOR_NAME
+              value: otel-collector
+            - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+              value: cumulative
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: service.name=$(OTEL_SERVICE_NAME),service.namespace=opentelemetry-demo,service.version=2.0.2
           resources:
             limits:
               memory: 20Mi


### PR DESCRIPTION
# Changes

Bump helm chart version from 0.32 to v0.37.

TODO: test to make sure everything still works
