### PR TITLE
Fix null values in collector config

### DIFF
--- a/gcp/opentelemetry-demo-values.yaml
+++ b/gcp/opentelemetry-demo-values.yaml
@@ -40,7 +40,7 @@ opentelemetry-collector:
     create: true
     name: "opentelemetry-demo-otelcol"
 
-  config:
+  alternateConfig:
     processors:
       memory_limiter:
         check_interval: 1s
@@ -80,6 +80,12 @@ opentelemetry-collector:
           metric:
           - '(IsMatch(name, "(.*)app_currency(.*)")) or (resource.attributes["service.name"] == "flagd")'
 
+      resource:
+        attributes:
+        - action: insert
+          from_attribute: k8s.pod.uid
+          key: service.instance.id
+
     exporters:
       googlecloud:
         log:
@@ -87,16 +93,29 @@ opentelemetry-collector:
 
       googlemanagedprometheus: {}
 
-      # Disable unused exporters
-      opensearch: null
-      otlp: null
-      otlphttp/prometheus: null
+    extensions:
+      health_check:
+        endpoint: ${env:MY_POD_IP}:13133
+
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: ${env:MY_POD_IP}:4317
+          http:
+            cors:
+              allowed_origins:
+              - http://*
+              - https://*
+            endpoint: ${env:MY_POD_IP}:4318
 
     service:
+      extensions: [health_check]
       telemetry:
         logs:
           encoding: json
         metrics:
+          level: detailed
           readers:
           - periodic:
               exporter:
@@ -105,9 +124,11 @@ opentelemetry-collector:
                   endpoint: ${env:MY_POD_IP}:4317
       pipelines:
         logs:
+          receivers: [otlp]
           processors: [resourcedetection, resource, memory_limiter, batch]
           exporters: [googlecloud]
         traces:
+          receivers: [otlp]
           processors: [memory_limiter, resourcedetection, resource, batch]
           exporters: [googlecloud]  # spanmetrics disabled
         metrics:

--- a/kubernetes/opentelemetry-demo.yaml
+++ b/kubernetes/opentelemetry-demo.yaml
@@ -100,13 +100,6 @@ data:
         detectors:
         - gcp
         timeout: 10s
-      transform:
-        error_mode: ignore
-        trace_statements:
-        - context: span
-          statements:
-          - replace_pattern(name, "\\?.*", "")
-          - replace_match(name, "GET /api/products/*", "GET /api/products/{productId}")
       transform/collision:
         metric_statements:
         - context: datapoint
@@ -124,17 +117,6 @@ data:
           - set(attributes["exported_project_id"], attributes["project_id"])
           - delete_key(attributes, "project_id")
     receivers:
-      httpcheck/frontend-proxy:
-        targets:
-        - endpoint: http://frontend-proxy:8080
-      jaeger:
-        protocols:
-          grpc:
-            endpoint: ${env:MY_POD_IP}:14250
-          thrift_compact:
-            endpoint: ${env:MY_POD_IP}:6831
-          thrift_http:
-            endpoint: ${env:MY_POD_IP}:14268
       otlp:
         protocols:
           grpc:
@@ -145,19 +127,6 @@ data:
               - http://*
               - https://*
             endpoint: ${env:MY_POD_IP}:4318
-      prometheus:
-        config:
-          scrape_configs:
-          - job_name: opentelemetry-collector
-            scrape_interval: 10s
-            static_configs:
-            - targets:
-              - ${env:MY_POD_IP}:8888
-      redis:
-        collection_interval: 10s
-        endpoint: valkey-cart:6379
-      zipkin:
-        endpoint: ${env:MY_POD_IP}:9411
     service:
       extensions:
       - health_check
@@ -197,8 +166,6 @@ data:
           - batch
           receivers:
           - otlp
-          - jaeger
-          - zipkin
       telemetry:
         logs:
           encoding: json
@@ -1019,7 +986,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1af4133983f76ceaf8e7f3b89c8dddfea01a1fc5adf4e89a301c17381e6d7c23
+        checksum/config: f3eb8c6ad4aa838e011ce057f9e4103b7ccb5e4154cc2e586b87a87f614f57ad
         opentelemetry_community_demo: "true"
         prometheus.io/scrape: "true"
       labels:


### PR DESCRIPTION
Switch from `config` to `alternateConfig` in the collector config to prevent null values in the collector configuration. See https://github.com/open-telemetry/opentelemetry-helm-charts/blob/6e902ed48b884409f6af25f30387ff69fcc165e4/charts/opentelemetry-collector/values.yaml#L224-L239

This allows us to fully overwrite the collector configuration, rather than merge with it. In order to maintain the existing behavior, I needed to add in the `resource` receiver, the `health_check` extension, and the `otlp` receiver.

I removed some unused receivers (jaeger, zipkin, prometheus, httpcheck), and an unused transform processor.

I tested by deploying in my own cluster.