### PR TITLE
feat: automate helm version bumps with Renovate and GHA

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["helmfile"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchPackageNames": ["helm/helm", "helmfile/helmfile"],
+      "groupName": "helm-tools"
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/regenerate-manifests\\.yml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+[A-Z_]+_VERSION=\"(?<currentValue>.*?)\""
+      ]
+    }
+  ]
+}

--- a/.github/workflows/regenerate-manifests.yml
+++ b/.github/workflows/regenerate-manifests.yml
@@ -1,0 +1,77 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+name: Regenerate Manifests
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'gcp/**'
+      - 'Makefile'
+      - '.github/workflows/regenerate-manifests.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
+          persist-credentials: true
+
+      - name: Install Helm and Helmfile
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/bin
+
+          # Install Helm
+          # renovate: datasource=github-releases depName=helm/helm
+          HELM_VERSION="v4.2.0"
+          curl -L -o helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz
+          tar -zxvf helm.tar.gz
+          mv linux-amd64/helm $GITHUB_WORKSPACE/bin/
+          rm -rf helm.tar.gz linux-amd64
+
+          # Install Helmfile
+          # renovate: datasource=github-releases depName=helmfile/helmfile
+          HELMFILE_VERSION="1.5.2"
+          curl -L -o helmfile.tar.gz https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_amd64.tar.gz
+          tar -zxvf helmfile.tar.gz helmfile
+          mv helmfile $GITHUB_WORKSPACE/bin/
+          rm -rf helmfile.tar.gz
+
+          # Add to PATH
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+      - name: Regenerate manifests
+        run: |
+          make generate-kubernetes-manifests
+
+      - name: Check for changes and commit/push
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add kubernetes/opentelemetry-demo.yaml
+
+          if ! git diff --quiet --staged; then
+            echo "Changes detected in regenerated manifests."
+
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+              echo "PR is from the same repository. Committing and pushing..."
+              git commit -m "chore: regenerate kubernetes manifests"
+              git push
+            else
+              echo "PR is from a fork. Cannot auto-commit due to GITHUB_TOKEN restrictions."
+              echo "Please run 'make generate-kubernetes-manifests' locally and push the changes."
+              echo "Showing diff for debugging:"
+              git diff --staged
+              exit 1
+            fi
+          else
+            echo "No changes detected. Manifests are up-to-date."
+          fi


### PR DESCRIPTION
### Problem

Manually bumping the upstream Helm chart version in `gcp/helmfile.yaml` and regenerating `kubernetes/opentelemetry-demo.yaml` is tedious and prone to being forgotten.

### Solution

This PR automates this process by:

1. Adding a Renovate configuration (`.github/renovate.json`) to automatically detect and propose updates to the Helm chart version in `gcp/helmfile.yaml`.
2. Adding a GitHub Actions workflow (`.github/workflows/regenerate-manifests.yml`) that automatically runs `make generate-kubernetes-manifests` whenever `gcp/` files are modified in a PR, and commits the regenerated `kubernetes/opentelemetry-demo.yaml` back to the PR branch.

This ensures that:
* We get automated PRs for new Helm chart releases.
* The generated Kubernetes manifests are always in sync with the helmfile, without requiring manual intervention.

Note: The workflow is designed to be fully secure and compliant with strict organization policies by avoiding third-party GitHub Actions. It installs Helm and Helmfile directly from official releases and uses standard git commands to commit changes.

Closes #329
